### PR TITLE
chore(ci): checkout with submodules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GIT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
           fetch-depth: 0
       - name: Set up JDK 17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          token: ${{ secrets.GIT_TOKEN }}
+          submodules: true
           fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v2


### PR DESCRIPTION
## Related Issue

## Description
- github action의 checkout 과정에서 submodule 코드까지 받아오도록 합니다.

## Screenshots (if appropriate):
