### PR TITLE
chore(env): Separate environment variable databases by profile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+    testImplementation 'org.projectlombok:lombok:1.18.26'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
@@ -72,6 +73,9 @@ dependencies {
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    //
+    testImplementation 'it.ozimov:embedded-redis:0.7.2'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,14 +44,16 @@ checkstyle {
 }
 
 dependencies {
-	  implementation 'org.springframework.boot:spring-boot-starter-web'
-	  implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	  implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
-	  implementation 'org.springframework.boot:spring-boot-starter-validation'
-	  implementation 'org.springframework.boot:spring-boot-starter-security:3.1.0'
-	  implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.1.0'
-	  implementation 'com.auth0:java-jwt:4.4.0'
-	  implementation 'org.flywaydb:flyway-core'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security:3.1.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.1.0'
+    implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.4.1'
+
+    implementation 'com.auth0:java-jwt:4.4.0'
+    implementation 'org.flywaydb:flyway-core'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
@@ -63,12 +65,12 @@ dependencies {
     implementation 'software.amazon.awssdk:ses:2.20.86'
     implementation 'software.amazon.awssdk:s3:2.20.82'
 
-	  testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	  testImplementation 'io.projectreactor:reactor-test'
-	  testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-	  testImplementation 'io.projectreactor:reactor-test'
-	  testImplementation 'org.springframework.security:spring-security-test'
-	  testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
+++ b/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
@@ -3,20 +3,22 @@ package com.e2i.wemeet.controller.admin;
 import static com.e2i.wemeet.controller.admin.AdminCollegeInfoFixture.ANYANG;
 import static com.e2i.wemeet.controller.admin.AdminCollegeInfoFixture.KU;
 import static com.e2i.wemeet.controller.admin.AdminCollegeInfoFixture.SEOUL_WOMAN;
+import static com.e2i.wemeet.controller.admin.AdminPreferenceFixture.GENERAL_PREFERENCE;
 
 import com.e2i.wemeet.domain.member.CollegeInfo;
 import com.e2i.wemeet.domain.member.Gender;
 import com.e2i.wemeet.domain.member.Mbti;
 import com.e2i.wemeet.domain.member.Member;
+import com.e2i.wemeet.domain.member.Preference;
 import com.e2i.wemeet.domain.member.Role;
 import java.util.Arrays;
 
 public enum AdminMemberFixture {
-    KAI("4100", "kai", Gender.MALE, "01012341234", ANYANG.create(), Mbti.INFJ,
+    KAI("4100", "kai", Gender.MALE, "01012341234", ANYANG.create(), GENERAL_PREFERENCE.create(), Mbti.INFJ,
         "hi", 100, Role.USER),
-    RIM("4101", "rim", Gender.FEMALE, "01088990011", SEOUL_WOMAN.create(), Mbti.ISTP,
+    RIM("4101", "rim", Gender.FEMALE, "01088990011", SEOUL_WOMAN.create(), GENERAL_PREFERENCE.create(), Mbti.ISTP,
         "hello", 100, Role.MANAGER),
-    SEYUN("4102", "seyun", Gender.MALE, "01033445566", KU.create(), Mbti.ESFJ,
+    SEYUN("4102", "seyun", Gender.MALE, "01033445566", KU.create(), GENERAL_PREFERENCE.create(), Mbti.ESFJ,
         "hey", 100, Role.USER)
 
     ;
@@ -26,18 +28,20 @@ public enum AdminMemberFixture {
     private final Gender gender;
     private final String phoneNumber;
     private final CollegeInfo collegeInfo;
+    private final Preference preference;
     private final Mbti mbti;
     private final String introduction;
     private final int credit;
     private final Role role;
 
     AdminMemberFixture(String memberCode, String nickname, Gender gender, String phoneNumber,
-        CollegeInfo collegeInfo, Mbti mbti, String introduction, int credit, Role role) {
+        CollegeInfo collegeInfo, Preference preference, Mbti mbti, String introduction, int credit, Role role) {
         this.memberCode = memberCode;
         this.nickname = nickname;
         this.gender = gender;
         this.phoneNumber = phoneNumber;
         this.collegeInfo = collegeInfo;
+        this.preference = preference;
         this.mbti = mbti;
         this.introduction = introduction;
         this.credit = credit;

--- a/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
+++ b/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
@@ -14,11 +14,14 @@ import com.e2i.wemeet.domain.member.Role;
 import java.util.Arrays;
 
 public enum AdminMemberFixture {
-    KAI("4100", "kai", Gender.MALE, "01012341234", ANYANG.create(), GENERAL_PREFERENCE.create(), Mbti.INFJ,
+    KAI("4100", "kai", Gender.MALE, "01012341234",
+        ANYANG.create(), GENERAL_PREFERENCE.create(), Mbti.INFJ,
         "hi", 100, Role.USER),
-    RIM("4101", "rim", Gender.FEMALE, "01088990011", SEOUL_WOMAN.create(), GENERAL_PREFERENCE.create(), Mbti.ISTP,
+    RIM("4101", "rim", Gender.FEMALE, "01088990011",
+        SEOUL_WOMAN.create(), GENERAL_PREFERENCE.create(), Mbti.ISTP,
         "hello", 100, Role.MANAGER),
-    SEYUN("4102", "seyun", Gender.MALE, "01033445566", KU.create(), GENERAL_PREFERENCE.create(), Mbti.ESFJ,
+    SEYUN("4102", "seyun", Gender.MALE, "01033445566",
+        KU.create(), GENERAL_PREFERENCE.create(), Mbti.ESFJ,
         "hey", 100, Role.USER)
 
     ;
@@ -79,6 +82,7 @@ public enum AdminMemberFixture {
             .gender(this.gender)
             .phoneNumber(this.phoneNumber)
             .collegeInfo(this.collegeInfo)
+            .preference(this.preference)
             .mbti(this.mbti)
             .introduction(this.introduction)
             .credit(this.credit)

--- a/src/main/java/com/e2i/wemeet/controller/admin/AdminPreferenceFixture.java
+++ b/src/main/java/com/e2i/wemeet/controller/admin/AdminPreferenceFixture.java
@@ -1,0 +1,44 @@
+package com.e2i.wemeet.controller.admin;
+
+import com.e2i.wemeet.domain.member.Preference;
+
+public enum AdminPreferenceFixture {
+
+    GENERAL_PREFERENCE(2019, 2022, true, true, true, "ENTP")
+    ;
+
+    private final int startPreferenceAdmissionYear;
+
+    private final int endPreferenceAdmissionYear;
+
+    private final boolean sameCollegeState;
+
+    private final boolean drinkingOption;
+
+    private final boolean isAvoidedFriends;
+
+    private final String preferenceMbti;
+
+    AdminPreferenceFixture(int startPreferenceAdmissionYear, int endPreferenceAdmissionYear,
+        boolean sameCollegeState, boolean drinkingOption, boolean isAvoidedFriends,
+        String preferenceMbti) {
+        this.startPreferenceAdmissionYear = startPreferenceAdmissionYear;
+        this.endPreferenceAdmissionYear = endPreferenceAdmissionYear;
+        this.sameCollegeState = sameCollegeState;
+        this.drinkingOption = drinkingOption;
+        this.isAvoidedFriends = isAvoidedFriends;
+        this.preferenceMbti = preferenceMbti;
+    }
+
+    public Preference create() {
+        return Preference.builder()
+            .startPreferenceAdmissionYear(startPreferenceAdmissionYear)
+            .endPreferenceAdmissionYear(endPreferenceAdmissionYear)
+            .sameCollegeState(sameCollegeState)
+            .drinkingOption(drinkingOption)
+            .isAvoidedFriends(isAvoidedFriends)
+            .preferenceMbti(preferenceMbti)
+            .build();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MariaDBDialect
     open-in-view: false
   h2:
     console:
@@ -20,7 +20,13 @@ spring:
   config:
     import: sub/application-jwt.yml, sub/application-aws.yml
   profiles:
-    active: dev
+    active: local
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+    import: sub/local/application-db.yml
 ---
 spring:
   config:

--- a/src/main/resources/db/migration/V2306210150__create_member.sql
+++ b/src/main/resources/db/migration/V2306210150__create_member.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS `member` (
     `member_id` bigint NOT NULL AUTO_INCREMENT,
+    `team_id` bigint,
     `member_code` char(4) NOT NULL,
     `nickname` varchar(20) NOT NULL,
     `gender` varchar(6) NOT NULL,
@@ -21,6 +22,7 @@ CREATE TABLE IF NOT EXISTS `member` (
     `modified_at` datetime(6),
     `role` varchar(8),
     PRIMARY KEY (`member_id`),
+    FOREIGN KEY (`team_id`) REFERENCES team (`team_id`),
     UNIQUE KEY `member_mail` (`mail`),
     UNIQUE KEY `member_phone_number` (`phone_number`))
     ENGINE = InnoDB

--- a/src/main/resources/db/migration/V2306210150__create_member.sql
+++ b/src/main/resources/db/migration/V2306210150__create_member.sql
@@ -1,6 +1,5 @@
 CREATE TABLE IF NOT EXISTS `member` (
     `member_id` bigint NOT NULL AUTO_INCREMENT,
-    `team_id` bigint,
     `member_code` char(4) NOT NULL,
     `nickname` varchar(20) NOT NULL,
     `gender` varchar(6) NOT NULL,
@@ -22,7 +21,6 @@ CREATE TABLE IF NOT EXISTS `member` (
     `modified_at` datetime(6),
     `role` varchar(8),
     PRIMARY KEY (`member_id`),
-    FOREIGN KEY (`team_id`) REFERENCES team (`team_id`),
     UNIQUE KEY `member_mail` (`mail`),
     UNIQUE KEY `member_phone_number` (`phone_number`))
     ENGINE = InnoDB

--- a/src/main/resources/db/migration/V2306211524__create_team.sql
+++ b/src/main/resources/db/migration/V2306211524__create_team.sql
@@ -13,3 +13,6 @@ CREATE TABLE IF NOT EXISTS `team` (
     FOREIGN KEY (`member_id`) REFERENCES `member` (`member_id`) ON DELETE CASCADE)
     ENGINE = InnoDB
     DEFAULT CHARACTER SET=utf8mb4;
+
+ALTER TABLE `member` ADD `team_id` bigint;
+ALTER TABLE `member` ADD FOREIGN KEY (`team_id`) REFERENCES team (`team_id`);

--- a/src/main/resources/db/migration/V2306211524__create_team.sql
+++ b/src/main/resources/db/migration/V2306211524__create_team.sql
@@ -10,9 +10,6 @@ CREATE TABLE IF NOT EXISTS `team` (
     `modified_at` datetime(6),
     `member_id` bigint NOT NULL,
     PRIMARY KEY (`team_id`),
-    FOREIGN KEY (`member_id`) REFERENCES member (`member_id`) ON DELETE CASCADE)
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`member_id`) ON DELETE CASCADE)
     ENGINE = InnoDB
     DEFAULT CHARACTER SET=utf8mb4;
-
-ALTER TABLE `member` ADD `team_id` bigint;
-ALTER TABLE `member` ADD FOREIGN KEY (`team_id`) REFERENCES team (`team_id`);

--- a/src/test/java/com/e2i/wemeet/WemeetApplicationTests.java
+++ b/src/test/java/com/e2i/wemeet/WemeetApplicationTests.java
@@ -1,10 +1,9 @@
 package com.e2i.wemeet;
 
+import com.e2i.wemeet.support.config.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
-class WemeetApplicationTests {
+class WemeetApplicationTests extends AbstractIntegrationTest {
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/e2i/wemeet/config/security/filter/SMSLoginProcessingFilterTest.java
+++ b/src/test/java/com/e2i/wemeet/config/security/filter/SMSLoginProcessingFilterTest.java
@@ -13,16 +13,13 @@ import com.e2i.wemeet.dto.request.LoginRequestDto;
 import com.e2i.wemeet.dto.request.credential.CredentialRequestDto;
 import com.e2i.wemeet.support.config.AbstractIntegrationTest;
 import com.e2i.wemeet.support.fixture.MemberFixture;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @DisplayName("SMS 인증 테스트")
 class SMSLoginProcessingFilterTest extends AbstractIntegrationTest {
 

--- a/src/test/java/com/e2i/wemeet/config/security/token/AccessTokenHandlerTest.java
+++ b/src/test/java/com/e2i/wemeet/config/security/token/AccessTokenHandlerTest.java
@@ -5,13 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.e2i.wemeet.config.security.token.handler.AccessTokenHandler;
 import com.e2i.wemeet.domain.member.Role;
+import com.e2i.wemeet.support.config.AbstractIntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
-class AccessTokenHandlerTest {
+class AccessTokenHandlerTest extends AbstractIntegrationTest {
+
     @Autowired
     private AccessTokenHandler accessTokenHandler;
 

--- a/src/test/java/com/e2i/wemeet/controller/admin/AdminCollegeInfoFixtureTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/admin/AdminCollegeInfoFixtureTest.java
@@ -1,0 +1,37 @@
+package com.e2i.wemeet.controller.admin;
+
+import static com.e2i.wemeet.controller.admin.AdminCollegeInfoFixture.KU;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.e2i.wemeet.domain.member.CollegeInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AdminCollegeInfoFixture 테스트")
+class AdminCollegeInfoFixtureTest {
+
+    @Test
+    void create() {
+        assertThat(KU.create()).isExactlyInstanceOf(CollegeInfo.class);
+    }
+
+    @Test
+    void getAdmissionYear() {
+        assertThat(KU.getAdmissionYear()).isGreaterThan(2000);
+    }
+
+    @Test
+    void getCollegeType() {
+        assertThat(KU.getCollegeType()).isExactlyInstanceOf(String.class);
+    }
+
+    @Test
+    void getCollege() {
+        assertThat(KU.getCollege()).isExactlyInstanceOf(String.class);
+    }
+
+    @Test
+    void getMail() {
+        assertThat(KU.getMail()).isExactlyInstanceOf(String.class);
+    }
+}

--- a/src/test/java/com/e2i/wemeet/controller/admin/AdminMemberFixtureTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/admin/AdminMemberFixtureTest.java
@@ -1,0 +1,47 @@
+package com.e2i.wemeet.controller.admin;
+
+import static com.e2i.wemeet.controller.admin.AdminMemberFixture.KAI;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.e2i.wemeet.domain.member.Member;
+import com.e2i.wemeet.domain.member.Role;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AdminMemberFixture 테스트")
+class AdminMemberFixtureTest {
+
+    @Test
+    void create() {
+        assertThat(KAI.create()).isExactlyInstanceOf(Member.class);
+    }
+
+    @Test
+    void createWithCredit() {
+        Member member = KAI.createWithCredit(1000);
+        assertThat(member.getCredit()).isEqualTo(1000);
+    }
+
+    @Test
+    void createWithRole() {
+        Member member = KAI.createWithRole(Role.MANAGER);
+        assertThat(member.getRole()).isEqualTo(Role.MANAGER);
+    }
+
+    @Test
+    void createWithRoleCredit() {
+        Member member = KAI.createWithRoleCredit(Role.MANAGER, 1000);
+        assertAll(
+            () -> assertThat(member.getRole()).isEqualTo(Role.MANAGER),
+            () -> assertThat(member.getCredit()).isEqualTo(1000)
+        );
+    }
+
+    @Test
+    void getFixture() {
+        final String name = "KAI";
+        assertThat(AdminMemberFixture.getFixture(name)).isEqualTo(KAI);
+    }
+}

--- a/src/test/java/com/e2i/wemeet/redis/RedisConnectionTest.java
+++ b/src/test/java/com/e2i/wemeet/redis/RedisConnectionTest.java
@@ -1,17 +1,14 @@
 package com.e2i.wemeet.redis;
 
+import com.e2i.wemeet.support.config.AbstractIntegrationTest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
-@SpringBootTest
-public class RedisConnectionTest {
+class RedisConnectionTest extends AbstractIntegrationTest {
 
     @Autowired
     private RedisTemplate<String, String> redisTemplate;

--- a/src/test/java/com/e2i/wemeet/service/admin/TestServiceTestAuthorization.java
+++ b/src/test/java/com/e2i/wemeet/service/admin/TestServiceTestAuthorization.java
@@ -8,19 +8,18 @@ import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.MemberRepository;
 import com.e2i.wemeet.exception.unauthorized.CreditNotEnoughException;
 import com.e2i.wemeet.exception.unauthorized.UnAuthorizedRoleException;
+import com.e2i.wemeet.support.config.AbstractIntegrationTest;
 import com.e2i.wemeet.support.config.WithCustomMockUser;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.access.AccessDeniedException;
 
 @DisplayName("Authorization Test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@SpringBootTest
-class TestServiceTestAuthorization {
+class TestServiceTestAuthorization extends AbstractIntegrationTest {
 
     @Autowired
     private TestAuthorizationService testAuthorizationService;

--- a/src/test/java/com/e2i/wemeet/support/config/AbstractIntegrationTest.java
+++ b/src/test/java/com/e2i/wemeet/support/config/AbstractIntegrationTest.java
@@ -4,14 +4,16 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 
 import com.e2i.wemeet.config.security.filter.AuthenticationExceptionFilter;
 import com.e2i.wemeet.config.security.filter.JwtAuthenticationFilter;
-import com.e2i.wemeet.config.security.filter.SMSLoginProcessingFilter;
 import com.e2i.wemeet.config.security.filter.RefreshTokenProcessingFilter;
+import com.e2i.wemeet.config.security.filter.SMSLoginProcessingFilter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.restdocs.RestDocumentationContextProvider;
@@ -26,6 +28,7 @@ import org.springframework.web.context.WebApplicationContext;
 * */
 @Transactional
 @SpringBootTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class AbstractIntegrationTest {

--- a/src/test/java/com/e2i/wemeet/support/config/EmbeddedRedisConfig.java
+++ b/src/test/java/com/e2i/wemeet/support/config/EmbeddedRedisConfig.java
@@ -1,0 +1,94 @@
+package com.e2i.wemeet.support.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.util.StringUtils;
+import redis.embedded.RedisServer;
+
+/*
+* Test 용 EmbeddedRedis / profile 이 local, default 일때만 활성화
+* */
+@Slf4j
+@Profile({"local", "default"})
+@Configuration
+public class EmbeddedRedisConfig {
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void redisServer() throws IOException {
+        // Application Context 가 2번 이상 실행될 때 포트 충돌 문제 해결
+        int port = isRedisRunning() ? findAvailablePort() : redisPort;
+
+        redisServer = new RedisServer(port);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    /**
+     * Embedded Redis가 현재 실행중인지 확인
+     */
+    private boolean isRedisRunning() throws IOException {
+        return isRunning(executeGrepProcessCommand(redisPort));
+    }
+
+    /**
+     * 현재 PC/서버에서 사용가능한 포트 조회
+     */
+    public int findAvailablePort() throws IOException {
+
+        for (int port = 10000; port <= 65535; port++) {
+            Process process = executeGrepProcessCommand(port);
+            if (!isRunning(process)) {
+                return port;
+            }
+        }
+
+        throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+    }
+
+    /**
+     * 해당 port를 사용중인 프로세스 확인하는 sh 실행
+     */
+    private Process executeGrepProcessCommand(int port) throws IOException {
+        String command = String.format("netstat -nat | grep LISTEN|grep %d", port);
+        String[] shell = {"/bin/sh", "-c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    /**
+     * 해당 Process가 현재 실행중인지 확인
+     */
+    private boolean isRunning(Process process) {
+        String line;
+        StringBuilder pidInfo = new StringBuilder();
+
+        try (BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+
+            while ((line = input.readLine()) != null) {
+                pidInfo.append(line);
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return StringUtils.hasText(pidInfo.toString());
+    }
+}

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -1,16 +1,19 @@
 package com.e2i.wemeet.support.fixture;
 
 import static com.e2i.wemeet.support.fixture.CollegeInfoFixture.ANYANG_COLLEGE;
+import static com.e2i.wemeet.support.fixture.PreferenceFixture.GENERAL_PREFERENCE;
 
 import com.e2i.wemeet.domain.member.CollegeInfo;
 import com.e2i.wemeet.domain.member.Gender;
 import com.e2i.wemeet.domain.member.Mbti;
 import com.e2i.wemeet.domain.member.Member;
+import com.e2i.wemeet.domain.member.Preference;
 import com.e2i.wemeet.domain.member.Role;
 
 public enum MemberFixture {
-    KAI("4100", "kai", Gender.MALE, "01012341234", ANYANG_COLLEGE.create(), Mbti.INFJ,
-        "안녕하세요", 100, Role.USER)
+    KAI("4100", "kai", Gender.MALE, "01012341234",
+        ANYANG_COLLEGE.create(), GENERAL_PREFERENCE.create(),
+        Mbti.INFJ, "안녕하세요", 100, Role.USER)
     ;
 
     private final String memberCode;
@@ -18,18 +21,20 @@ public enum MemberFixture {
     private final Gender gender;
     private final String phoneNumber;
     private final CollegeInfo collegeInfo;
+    private final Preference preference;
     private final Mbti mbti;
     private final String introduction;
     private final int credit;
     private final Role role;
 
     MemberFixture(String memberCode, String nickname, Gender gender, String phoneNumber,
-        CollegeInfo collegeInfo, Mbti mbti, String introduction, int credit, Role role) {
+        CollegeInfo collegeInfo, Preference preference, Mbti mbti, String introduction, int credit, Role role) {
         this.memberCode = memberCode;
         this.nickname = nickname;
         this.gender = gender;
         this.phoneNumber = phoneNumber;
         this.collegeInfo = collegeInfo;
+        this.preference = preference;
         this.mbti = mbti;
         this.introduction = introduction;
         this.credit = credit;

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -72,6 +72,7 @@ public enum MemberFixture {
             .gender(this.gender)
             .phoneNumber(this.phoneNumber)
             .collegeInfo(this.collegeInfo)
+            .preference(this.preference)
             .mbti(this.mbti)
             .introduction(this.introduction)
             .credit(this.credit)

--- a/src/test/java/com/e2i/wemeet/support/fixture/PreferenceFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/PreferenceFixture.java
@@ -1,0 +1,44 @@
+package com.e2i.wemeet.support.fixture;
+
+import com.e2i.wemeet.domain.member.Preference;
+
+public enum PreferenceFixture {
+
+    GENERAL_PREFERENCE(2019, 2022, true, true, true, "ENTP")
+    ;
+
+    private final int startPreferenceAdmissionYear;
+
+    private final int endPreferenceAdmissionYear;
+
+    private final boolean sameCollegeState;
+
+    private final boolean drinkingOption;
+
+    private final boolean isAvoidedFriends;
+
+    private final String preferenceMbti;
+
+    PreferenceFixture(int startPreferenceAdmissionYear, int endPreferenceAdmissionYear,
+        boolean sameCollegeState, boolean drinkingOption, boolean isAvoidedFriends,
+        String preferenceMbti) {
+        this.startPreferenceAdmissionYear = startPreferenceAdmissionYear;
+        this.endPreferenceAdmissionYear = endPreferenceAdmissionYear;
+        this.sameCollegeState = sameCollegeState;
+        this.drinkingOption = drinkingOption;
+        this.isAvoidedFriends = isAvoidedFriends;
+        this.preferenceMbti = preferenceMbti;
+    }
+
+    public Preference create() {
+        return Preference.builder()
+            .startPreferenceAdmissionYear(startPreferenceAdmissionYear)
+            .endPreferenceAdmissionYear(endPreferenceAdmissionYear)
+            .sameCollegeState(sameCollegeState)
+            .drinkingOption(drinkingOption)
+            .isAvoidedFriends(isAvoidedFriends)
+            .preferenceMbti(preferenceMbti)
+            .build();
+    }
+
+}


### PR DESCRIPTION
## Related Issue
#34 

## Description
- 로컬 환경에서는 Docker로 띄운 Redis와 InMemoryDB인 H2에 연결합니다.
- 개발/운영 환경에서는 AWS ElastiCache 와 RDS에 연결합니다.

- 다음 명령어로 특정 프로필을 활성화 시켜 테스트를 수행할 수 있습니다.
```
SPRING_PROFILES_ACTIVE=dev ./gradlew clean test
```