### PR TITLE
refactor(token): Change Token Reissuance Logic Using Refresh Token

### DIFF
--- a/src/main/java/com/e2i/wemeet/config/security/config/SecurityBeanConfig.java
+++ b/src/main/java/com/e2i/wemeet/config/security/config/SecurityBeanConfig.java
@@ -63,9 +63,9 @@ public class SecurityBeanConfig {
     @Bean
     public RefreshTokenProcessingFilter refreshTokenProcessingFilter(
         RedisTemplate<String, String> redisTemplate, RefreshTokenHandler refreshTokenHandler,
-        TokenInjector tokenInjector, ObjectMapper objectMapper) {
+        TokenInjector tokenInjector, ObjectMapper objectMapper, AccessTokenHandler accessTokenHandler) {
         return new RefreshTokenProcessingFilter(redisTemplate, refreshTokenHandler, tokenInjector,
-            objectMapper);
+            objectMapper, accessTokenHandler);
     }
 
     // AccessToken 유효성 검증 필터

--- a/src/main/java/com/e2i/wemeet/config/security/provider/SmsCredentialAuthenticationProvider.java
+++ b/src/main/java/com/e2i/wemeet/config/security/provider/SmsCredentialAuthenticationProvider.java
@@ -35,8 +35,7 @@ public class SmsCredentialAuthenticationProvider implements AuthenticationProvid
             throw new InvalidSmsCredentialException(ErrorCode.INVALID_SMS_CREDENTIAL);
         }
 
-        UserDetails userDetails = userDetailsService.loadUserByUsername(
-            EncryptionUtils.hashData(phone));
+        UserDetails userDetails = userDetailsService.loadUserByUsername(phone);
 
         // 인증된 객체 반환 authenticated == true
         return new UsernamePasswordAuthenticationToken(userDetails, null,

--- a/src/main/java/com/e2i/wemeet/config/security/provider/SmsUserDetailsService.java
+++ b/src/main/java/com/e2i/wemeet/config/security/provider/SmsUserDetailsService.java
@@ -19,7 +19,7 @@ public class SmsUserDetailsService implements UserDetailsService {
      */
     @Override
     public UserDetails loadUserByUsername(final String username) throws UsernameNotFoundException {
-        String hashPhoneNumber = EncryptionUtils.hashData(username.replace("+82", "0"));
+        String hashPhoneNumber = EncryptionUtils.hashData(username);
 
         Member member = memberRepository.findByPhoneNumber(hashPhoneNumber).orElse(null);
 

--- a/src/main/java/com/e2i/wemeet/config/security/provider/SmsUserDetailsService.java
+++ b/src/main/java/com/e2i/wemeet/config/security/provider/SmsUserDetailsService.java
@@ -3,6 +3,7 @@ package com.e2i.wemeet.config.security.provider;
 import com.e2i.wemeet.config.security.model.MemberPrincipal;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.MemberRepository;
+import com.e2i.wemeet.util.encryption.EncryptionUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -17,8 +18,10 @@ public class SmsUserDetailsService implements UserDetailsService {
      * username == phone
      */
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByPhoneNumber(username).orElse(null);
+    public UserDetails loadUserByUsername(final String username) throws UsernameNotFoundException {
+        String hashPhoneNumber = EncryptionUtils.hashData(username.replace("+82", "0"));
+
+        Member member = memberRepository.findByPhoneNumber(hashPhoneNumber).orElse(null);
 
         // SMS 인증을 요청한 사용자가 회원가입이 되어있지 않을 경우
         if (member == null) {

--- a/src/main/java/com/e2i/wemeet/config/security/token/TokenInjector.java
+++ b/src/main/java/com/e2i/wemeet/config/security/token/TokenInjector.java
@@ -4,7 +4,6 @@ package com.e2i.wemeet.config.security.token;
 import com.e2i.wemeet.config.security.model.MemberPrincipal;
 import com.e2i.wemeet.config.security.token.handler.AccessTokenHandler;
 import com.e2i.wemeet.config.security.token.handler.RefreshTokenHandler;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
@@ -41,9 +40,8 @@ public class TokenInjector {
 
     private void injectRefreshToken(HttpServletResponse response, Payload payload) {
         String refreshToken = refreshTokenHandler.createToken(payload);
-        Cookie refreshTokenCookie = createRefreshTokenCookie(refreshToken);
         saveRefreshTokenInRedis(payload, refreshToken);
-        response.addCookie(refreshTokenCookie);
+        response.setHeader(JwtEnv.REFRESH.getKey(), refreshToken);
     }
 
     public void injectAccessToken(HttpServletResponse response, Payload payload) {
@@ -62,11 +60,4 @@ public class TokenInjector {
         operations.set(redisKey, refreshToken, refreshTokenDuration);
     }
 
-    private Cookie createRefreshTokenCookie(String refreshToken) {
-        Cookie refreshTokenCookie = new Cookie(JwtEnv.REFRESH.getKey(), refreshToken);
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setSecure(true);
-        refreshTokenCookie.setMaxAge((int) Duration.ofMinutes(10).toSeconds());
-        return refreshTokenCookie;
-    }
 }

--- a/src/main/java/com/e2i/wemeet/config/security/token/handler/AccessTokenHandler.java
+++ b/src/main/java/com/e2i/wemeet/config/security/token/handler/AccessTokenHandler.java
@@ -44,6 +44,17 @@ public class AccessTokenHandler extends TokenHandler {
         return new Payload(decodedJWT.getClaims());
     }
 
+    public Payload extractTokenWithNoVerify(String accessTokenWithPrefix) {
+        String accessToken = separatePrefix(accessTokenWithPrefix);
+        if (!StringUtils.hasText(accessToken)) {
+            return null;
+        }
+
+        // AccessToken 검증 & 파싱
+        DecodedJWT decodedJWT = JWT.decode(accessToken);
+        return new Payload(decodedJWT.getClaims());
+    }
+
     private String separatePrefix(String accessTokenWithPrefix) {
         if (accessTokenWithPrefix != null && accessTokenWithPrefix.startsWith(ACCESS_PREFIX)) {
             return accessTokenWithPrefix.replace(ACCESS_PREFIX, "");

--- a/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
+++ b/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
@@ -15,13 +15,13 @@ import com.e2i.wemeet.util.encryption.EncryptionUtils;
 import java.util.Arrays;
 
 public enum AdminMemberFixture {
-    KAI("4100", "kai", Gender.MALE, "01012341234",
+    KAI("4100", "kai", Gender.MALE, "+821012341234",
         ANYANG.create(), GENERAL_PREFERENCE.create(), Mbti.INFJ,
         "hi", 100, Role.USER),
-    RIM("4101", "rim", Gender.FEMALE, "01088990011",
+    RIM("4101", "rim", Gender.FEMALE, "+821088990011",
         SEOUL_WOMAN.create(), GENERAL_PREFERENCE.create(), Mbti.ISTP,
         "hello", 100, Role.MANAGER),
-    SEYUN("4102", "seyun", Gender.MALE, "01033445566",
+    SEYUN("4102", "seyun", Gender.MALE, "+821033445566",
         KU.create(), GENERAL_PREFERENCE.create(), Mbti.ESFJ,
         "hey", 100, Role.USER)
 

--- a/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
+++ b/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
@@ -11,6 +11,7 @@ import com.e2i.wemeet.domain.member.Mbti;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.Preference;
 import com.e2i.wemeet.domain.member.Role;
+import com.e2i.wemeet.util.encryption.EncryptionUtils;
 import java.util.Arrays;
 
 public enum AdminMemberFixture {
@@ -76,11 +77,13 @@ public enum AdminMemberFixture {
     }
 
     private Member.MemberBuilder createBuilder() {
+        String hashPhoneNumber = EncryptionUtils.hashData(this.phoneNumber);
+
         return Member.builder()
             .memberCode(this.memberCode)
             .nickname(this.nickname)
             .gender(this.gender)
-            .phoneNumber(this.phoneNumber)
+            .phoneNumber(hashPhoneNumber)
             .collegeInfo(this.collegeInfo)
             .preference(this.preference)
             .mbti(this.mbti)

--- a/src/main/java/com/e2i/wemeet/util/encryption/EncryptionUtils.java
+++ b/src/main/java/com/e2i/wemeet/util/encryption/EncryptionUtils.java
@@ -23,14 +23,4 @@ public abstract class EncryptionUtils {
             throw new InternalServerException(DATA_ENCRYPTION_ERROR);
         }
     }
-
-    public static String decodeHashData(String data) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] encodedHash = digest.digest(data.getBytes(StandardCharsets.UTF_8));
-            return Arrays.toString(Base64.getDecoder().decode(encodedHash));
-        } catch (NoSuchAlgorithmException e) {
-            throw new InternalServerException(DATA_ENCRYPTION_ERROR);
-        }
-    }
 }

--- a/src/main/java/com/e2i/wemeet/util/encryption/EncryptionUtils.java
+++ b/src/main/java/com/e2i/wemeet/util/encryption/EncryptionUtils.java
@@ -6,6 +6,7 @@ import com.e2i.wemeet.exception.internal.InternalServerException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Base64;
 
 public abstract class EncryptionUtils {
@@ -18,6 +19,16 @@ public abstract class EncryptionUtils {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] encodedHash = digest.digest(data.getBytes(StandardCharsets.UTF_8));
             return Base64.getEncoder().encodeToString(encodedHash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new InternalServerException(DATA_ENCRYPTION_ERROR);
+        }
+    }
+
+    public static String decodeHashData(String data) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] encodedHash = digest.digest(data.getBytes(StandardCharsets.UTF_8));
+            return Arrays.toString(Base64.getDecoder().decode(encodedHash));
         } catch (NoSuchAlgorithmException e) {
             throw new InternalServerException(DATA_ENCRYPTION_ERROR);
         }

--- a/src/test/java/com/e2i/wemeet/config/security/filter/RefreshTokenProcessingFilterTest.java
+++ b/src/test/java/com/e2i/wemeet/config/security/filter/RefreshTokenProcessingFilterTest.java
@@ -1,6 +1,7 @@
 package com.e2i.wemeet.config.security.filter;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -11,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.e2i.wemeet.config.security.token.JwtEnv;
 import com.e2i.wemeet.config.security.token.Payload;
+import com.e2i.wemeet.config.security.token.handler.AccessTokenHandler;
 import com.e2i.wemeet.config.security.token.handler.RefreshTokenHandler;
 import com.e2i.wemeet.domain.member.Role;
 import com.e2i.wemeet.exception.token.RefreshTokenMismatchException;
@@ -37,12 +39,16 @@ class RefreshTokenProcessingFilterTest extends AbstractIntegrationTest {
     @Autowired
     private RefreshTokenHandler refreshTokenHandler;
 
+    @Autowired
+    private AccessTokenHandler accessTokenHandler;
+
     @DisplayName("refresh token을 이용하여 access token을 재발급한다.")
     @Test
     void refresh() throws Exception {
         // set
         Payload payload = new Payload(100L, Role.USER.name());
         String refreshToken = refreshTokenHandler.createToken(payload);
+        String accessToken = accessTokenHandler.createToken(payload);
 
         ValueOperations<String, String> operations = redisTemplate.opsForValue();
 
@@ -53,22 +59,22 @@ class RefreshTokenProcessingFilterTest extends AbstractIntegrationTest {
         ResultActions perform = mvc.perform(
             RestDocumentationRequestBuilders.post("/v1/auth/refresh")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .content(toJson(payload))
-                .cookie(new Cookie(JwtEnv.REFRESH.getKey(), refreshToken))
+                .header(JwtEnv.ACCESS.getKey(), accessToken)
+                .header(JwtEnv.REFRESH.getKey(), refreshToken)
         );
 
         // when
         perform.andExpectAll(
             status().isOk(),
             header().exists(JwtEnv.ACCESS.getKey()),
-            cookie().exists(JwtEnv.REFRESH.getKey())
+            header().exists(JwtEnv.REFRESH.getKey())
         );
 
         writeRestDocs(perform);
     }
 
     @DisplayName("refresh token 이 다를 경우 재발급에 실패한다.")
-    //@Test
+        //@Test
     void refreshFail() {
         // set
         Payload payload = new Payload(100L, Role.USER.name());
@@ -99,18 +105,26 @@ class RefreshTokenProcessingFilterTest extends AbstractIntegrationTest {
                         .summary("RefreshToken 을 사용하여 Access, Refresh Token을 갱신합니다.")
                         .description(
                             """
-                                RefreshToken 을 사용하여 Access, Refresh Token을 갱신합니다. \n
-                                현재 사용자의 memberId와 role, Cookie에 RefreshToken 값을 넘겨주어야합니다.
-                            """),
-                    requestFields(
-                        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("사용자 ID"),
-                        fieldWithPath("role").type(JsonFieldType.STRING).description("사용자 권한")
-                    ),
-                    responseFields(
-                        fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
-                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
-                        fieldWithPath("data").type(JsonFieldType.NULL).description("data 는 null 입니다.")
-                    )
+                                    Access Token & RefreshToken 을 사용하여 Access, Refresh Token을 갱신합니다. \n
+                                    Access Token과 Refresh Token 을 Header 에 넘겨주어야합니다.
+                                    Access Token 은 유저의 값을 받아오는 용도이기 때문에 만료된 상태여도 상관 없습니다.
+                                """
+                        )
+                        .requestHeaders(
+                            headerWithName(JwtEnv.ACCESS.getKey()).description("Access Token"),
+                            headerWithName(JwtEnv.REFRESH.getKey()).description("Refresh Token")
+                        )
+                        .responseHeaders(
+                            headerWithName(JwtEnv.ACCESS.getKey()).description("Access Token"),
+                            headerWithName(JwtEnv.REFRESH.getKey()).description("Refresh Token")
+                        )
+                        .responseFields(
+                            fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                            fieldWithPath("message").type(JsonFieldType.STRING)
+                                .description("응답 메시지"),
+                            fieldWithPath("data").type(JsonFieldType.NULL)
+                                .description("data 는 null 입니다.")
+                        )
                 ));
     }
 }

--- a/src/test/java/com/e2i/wemeet/config/security/filter/SMSLoginProcessingFilterTest.java
+++ b/src/test/java/com/e2i/wemeet/config/security/filter/SMSLoginProcessingFilterTest.java
@@ -99,7 +99,7 @@ class SMSLoginProcessingFilterTest extends AbstractIntegrationTest {
         perform.andExpectAll(
             status().isOk(),
             header().exists(JwtEnv.ACCESS.getKey()),
-            cookie().exists(JwtEnv.REFRESH.getKey()),
+            header().exists(JwtEnv.REFRESH.getKey()),
             jsonPath("$.status").value("SUCCESS"),
             jsonPath("$.message").value("인증에 성공하였습니다."),
             jsonPath("$.data").isNotEmpty()

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -12,7 +12,7 @@ import com.e2i.wemeet.domain.member.Role;
 import com.e2i.wemeet.util.encryption.EncryptionUtils;
 
 public enum MemberFixture {
-    KAI("4100", "kai", Gender.MALE, EncryptionUtils.hashData("+821012341234"),
+    KAI("4100", "kai", Gender.MALE, EncryptionUtils.hashData("01012341234"),
         ANYANG_COLLEGE.create(), GENERAL_PREFERENCE.create(),
         Mbti.INFJ, "안녕하세요", 100, Role.USER);
 

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -12,7 +12,7 @@ import com.e2i.wemeet.domain.member.Role;
 import com.e2i.wemeet.util.encryption.EncryptionUtils;
 
 public enum MemberFixture {
-    KAI("4100", "kai", Gender.MALE, EncryptionUtils.hashData("01012341234"),
+    KAI("4100", "kai", Gender.MALE, EncryptionUtils.hashData("+821012341234"),
         ANYANG_COLLEGE.create(), GENERAL_PREFERENCE.create(),
         Mbti.INFJ, "안녕하세요", 100, Role.USER);
 

--- a/src/test/java/com/e2i/wemeet/util/encryption/EncryptionUtilsTest.java
+++ b/src/test/java/com/e2i/wemeet/util/encryption/EncryptionUtilsTest.java
@@ -1,0 +1,24 @@
+package com.e2i.wemeet.util.encryption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EncryptionUtilsTest {
+
+    @DisplayName("해시 데이터를 생성하는데 성공한다")
+    @ValueSource(strings = {"kia", "email@email.com", "+821012345678"})
+    @ParameterizedTest
+    void hashData(final String data) {
+        // when
+        String encryptedData = EncryptionUtils.hashData(data);
+
+        // then
+        assertThat(encryptedData).isNotEqualTo(data);
+    }
+}


### PR DESCRIPTION
## Related Issue
#45 

## Description
- refresh token을 통해 토큰을 재발급 받을 때 body에 유저 정보를 담는 것이 아닌, access token을 활용하도록 합니다.
- refresh token을 헤더를 통해 클라이언트에게 전달합니다.

## Screenshots (if appropriate):

## Checklist:
- [x] refresh token 조회 경로 변경
- [x] refresh token 응답 방식 변경 (header)
- [x] 토큰 재발급 로직 수정 (AccessToken, RefreshToken 사용)
- [x] Test 수정