### PR TITLE
feat(encrypt): add Two-Way encryption module

### DIFF
--- a/src/main/java/com/e2i/wemeet/config/WebConfig.java
+++ b/src/main/java/com/e2i/wemeet/config/WebConfig.java
@@ -3,10 +3,14 @@ package com.e2i.wemeet.config;
 import com.e2i.wemeet.config.aws.AwsS3Config;
 import com.e2i.wemeet.config.aws.AwsSesConfig;
 import com.e2i.wemeet.config.aws.AwsSnsConfig;
+import com.e2i.wemeet.util.encryption.AdvancedEncryptionStandard;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@EnableConfigurationProperties({AwsSesConfig.class, AwsSnsConfig.class, AwsS3Config.class})
+@EnableConfigurationProperties({
+    AwsSesConfig.class, AwsSnsConfig.class, AwsS3Config.class,
+    AdvancedEncryptionStandard.class
+})
 @Configuration
 public class WebConfig {
 

--- a/src/main/java/com/e2i/wemeet/config/security/config/SecurityBeanConfig.java
+++ b/src/main/java/com/e2i/wemeet/config/security/config/SecurityBeanConfig.java
@@ -13,6 +13,7 @@ import com.e2i.wemeet.config.security.token.handler.AccessTokenHandler;
 import com.e2i.wemeet.config.security.token.handler.RefreshTokenHandler;
 import com.e2i.wemeet.domain.member.MemberRepository;
 import com.e2i.wemeet.service.credential.sms.SmsCredentialService;
+import com.e2i.wemeet.util.encryption.TwoWayEncryption;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
@@ -97,8 +98,8 @@ public class SecurityBeanConfig {
 
     // UserDetailService - 유저가 입력한 값에 대한 인증 정보를 가져옴
     @Bean
-    public UserDetailsService userDetailsService(MemberRepository memberRepository) {
-        return new SmsUserDetailsService(memberRepository);
+    public UserDetailsService userDetailsService(MemberRepository memberRepository, TwoWayEncryption twoWayEncryption) {
+        return new SmsUserDetailsService(memberRepository, twoWayEncryption);
     }
 
     // 사용자 로그인 요청 성공시 수행

--- a/src/main/java/com/e2i/wemeet/config/security/config/SecurityBeanConfig.java
+++ b/src/main/java/com/e2i/wemeet/config/security/config/SecurityBeanConfig.java
@@ -98,8 +98,8 @@ public class SecurityBeanConfig {
 
     // UserDetailService - 유저가 입력한 값에 대한 인증 정보를 가져옴
     @Bean
-    public UserDetailsService userDetailsService(MemberRepository memberRepository, TwoWayEncryption twoWayEncryption) {
-        return new SmsUserDetailsService(memberRepository, twoWayEncryption);
+    public UserDetailsService userDetailsService(MemberRepository memberRepository) {
+        return new SmsUserDetailsService(memberRepository);
     }
 
     // 사용자 로그인 요청 성공시 수행

--- a/src/main/java/com/e2i/wemeet/config/security/provider/SmsUserDetailsService.java
+++ b/src/main/java/com/e2i/wemeet/config/security/provider/SmsUserDetailsService.java
@@ -3,7 +3,7 @@ package com.e2i.wemeet.config.security.provider;
 import com.e2i.wemeet.config.security.model.MemberPrincipal;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.MemberRepository;
-import com.e2i.wemeet.util.encryption.EncryptionUtils;
+import com.e2i.wemeet.util.encryption.TwoWayEncryption;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -13,15 +13,15 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 public class SmsUserDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
+    private final TwoWayEncryption encryption;
 
     /*
      * username == phone
      */
     @Override
     public UserDetails loadUserByUsername(final String username) throws UsernameNotFoundException {
-        String hashPhoneNumber = EncryptionUtils.hashData(username);
-
-        Member member = memberRepository.findByPhoneNumber(hashPhoneNumber).orElse(null);
+        String encryptedPhoneNumber = encryption.encrypt(username);
+        Member member = memberRepository.findByPhoneNumber(encryptedPhoneNumber).orElse(null);
 
         // SMS 인증을 요청한 사용자가 회원가입이 되어있지 않을 경우
         if (member == null) {

--- a/src/main/java/com/e2i/wemeet/config/security/provider/SmsUserDetailsService.java
+++ b/src/main/java/com/e2i/wemeet/config/security/provider/SmsUserDetailsService.java
@@ -3,7 +3,6 @@ package com.e2i.wemeet.config.security.provider;
 import com.e2i.wemeet.config.security.model.MemberPrincipal;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.MemberRepository;
-import com.e2i.wemeet.util.encryption.TwoWayEncryption;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -13,15 +12,13 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 public class SmsUserDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
-    private final TwoWayEncryption encryption;
 
     /*
      * username == phone
      */
     @Override
     public UserDetails loadUserByUsername(final String username) throws UsernameNotFoundException {
-        String encryptedPhoneNumber = encryption.encrypt(username);
-        Member member = memberRepository.findByPhoneNumber(encryptedPhoneNumber).orElse(null);
+        Member member = memberRepository.findByPhoneNumber(username).orElse(null);
 
         // SMS 인증을 요청한 사용자가 회원가입이 되어있지 않을 경우
         if (member == null) {

--- a/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
+++ b/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
@@ -11,7 +11,6 @@ import com.e2i.wemeet.domain.member.Mbti;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.Preference;
 import com.e2i.wemeet.domain.member.Role;
-import com.e2i.wemeet.util.encryption.EncryptionUtils;
 import java.util.Arrays;
 
 public enum AdminMemberFixture {
@@ -77,13 +76,11 @@ public enum AdminMemberFixture {
     }
 
     private Member.MemberBuilder createBuilder() {
-        String hashPhoneNumber = EncryptionUtils.hashData(this.phoneNumber);
-
         return Member.builder()
             .memberCode(this.memberCode)
             .nickname(this.nickname)
             .gender(this.gender)
-            .phoneNumber(hashPhoneNumber)
+            .phoneNumber(this.phoneNumber)
             .collegeInfo(this.collegeInfo)
             .preference(this.preference)
             .mbti(this.mbti)

--- a/src/main/java/com/e2i/wemeet/controller/admin/TestTokenInjectionController.java
+++ b/src/main/java/com/e2i/wemeet/controller/admin/TestTokenInjectionController.java
@@ -11,11 +11,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 /*
 * profile 이 prod 가 아닐 때만 동작하는 Controller
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequiredArgsConstructor
 @Transactional
 @Profile("!prod")
-@Controller
+@RestController
 public class TestTokenInjectionController {
 
     private final TokenInjector tokenInjector;

--- a/src/main/java/com/e2i/wemeet/domain/base/CryptoConverter.java
+++ b/src/main/java/com/e2i/wemeet/domain/base/CryptoConverter.java
@@ -1,0 +1,34 @@
+package com.e2i.wemeet.domain.base;
+
+import com.e2i.wemeet.util.encryption.TwoWayEncryption;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.springframework.stereotype.Component;
+
+@Converter
+@Component
+public class CryptoConverter implements AttributeConverter<String, String> {
+    private final TwoWayEncryption twoWayEncryption;
+
+    public CryptoConverter(TwoWayEncryption twoWayEncryption) {
+        this.twoWayEncryption = twoWayEncryption;
+    }
+
+    // DB에 저장될 때 (암호화)
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return twoWayEncryption.encrypt(attribute);
+    }
+
+    // DB에서 읽어올 때 (복호화)
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return twoWayEncryption.decrypt(dbData);
+    }
+}

--- a/src/main/java/com/e2i/wemeet/domain/member/CollegeInfo.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/CollegeInfo.java
@@ -1,6 +1,8 @@
 package com.e2i.wemeet.domain.member;
 
+import com.e2i.wemeet.domain.base.CryptoConverter;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,6 +23,7 @@ public class CollegeInfo {
     @Column(length = 2, nullable = false)
     private String admissionYear;
 
+    @Convert(converter = CryptoConverter.class)
     @Column(length = 60, unique = true)
     private String mail;
 

--- a/src/main/java/com/e2i/wemeet/domain/member/Member.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/Member.java
@@ -1,9 +1,11 @@
 package com.e2i.wemeet.domain.member;
 
 import com.e2i.wemeet.domain.base.BaseTimeEntity;
+import com.e2i.wemeet.domain.base.CryptoConverter;
 import com.e2i.wemeet.domain.team.Team;
 import com.e2i.wemeet.exception.unauthorized.CreditNotEnoughException;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -40,6 +42,7 @@ public class Member extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private Gender gender;
 
+    @Convert(converter = CryptoConverter.class)
     @Column(length = 60, unique = true, nullable = false)
     private String phoneNumber;
 

--- a/src/main/java/com/e2i/wemeet/dto/request/member/CreateMemberRequestDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/request/member/CreateMemberRequestDto.java
@@ -6,7 +6,6 @@ import com.e2i.wemeet.domain.member.Mbti;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.Preference;
 import com.e2i.wemeet.domain.member.Role;
-import com.e2i.wemeet.util.encryption.EncryptionUtils;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -51,7 +50,7 @@ public record CreateMemberRequestDto(
             .memberCode(memberCode)
             .nickname(nickname)
             .gender(Gender.findBy(gender))
-            .phoneNumber(EncryptionUtils.hashData(phoneNumber))
+            .phoneNumber(phoneNumber)
             .collegeInfo(CollegeInfo.builder()
                 .college(collegeInfo.college())
                 .collegeType(collegeInfo.collegeType())

--- a/src/main/java/com/e2i/wemeet/exception/ErrorCode.java
+++ b/src/main/java/com/e2i/wemeet/exception/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
     MISSING_REQUEST_PARAMETER(50001, "missing.request.parameter"),
     DATA_ENCRYPTION_ERROR(50002, "data.encryption.error"),
     MAIL_JSON_PARSING_ERROR(50003, "mail.json.parsing.error"),
+    DATA_DECRYPTION_ERROR(50004, "data.decryption.error"),
 
     AWS_SNS_MESSAGE_TRANSFER_ERROR(50100, "aws.sns.message.transfer.error"),
 

--- a/src/main/java/com/e2i/wemeet/service/aws/ses/AwsSesService.java
+++ b/src/main/java/com/e2i/wemeet/service/aws/ses/AwsSesService.java
@@ -61,7 +61,7 @@ public class AwsSesService implements EmailCredentialService {
         boolean result = origin.equals(input);
         if (result) {
             memberRepository.findById(memberId).ifPresent(member ->
-                member.getCollegeInfo().saveMail(EncryptionUtils.hashData(target)));
+                member.getCollegeInfo().saveMail(target));
         }
 
         return result;

--- a/src/main/java/com/e2i/wemeet/util/encryption/AdvancedEncryptionStandard.java
+++ b/src/main/java/com/e2i/wemeet/util/encryption/AdvancedEncryptionStandard.java
@@ -1,0 +1,56 @@
+package com.e2i.wemeet.util.encryption;
+
+import static com.e2i.wemeet.exception.ErrorCode.DATA_DECRYPTION_ERROR;
+import static com.e2i.wemeet.exception.ErrorCode.DATA_ENCRYPTION_ERROR;
+
+import com.e2i.wemeet.exception.internal.InternalServerException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Primary;
+
+@ConfigurationProperties(prefix = "security.encrypt")
+@Primary
+public class AdvancedEncryptionStandard implements TwoWayEncryption {
+    private final String alg;
+    private final String key;
+    private final SecretKeySpec secretKeySpec;
+    private final IvParameterSpec ivParamSpec;
+
+    public AdvancedEncryptionStandard(String alg, String key) {
+        this.alg = alg;
+        this.key = key;
+        this.secretKeySpec = new SecretKeySpec(key.getBytes(), "AES");
+        this.ivParamSpec = new IvParameterSpec(key.substring(0, 16).getBytes());
+    }
+
+    @Override
+    public String encrypt(String text) {
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivParamSpec);
+
+            byte[] encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (Exception e) {
+            throw new InternalServerException(DATA_ENCRYPTION_ERROR);
+        }
+    }
+
+    @Override
+    public String decrypt(String cipherText) {
+        try {
+            Cipher cipher = Cipher.getInstance(alg);
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivParamSpec);
+
+            byte[] decodedBytes = Base64.getDecoder().decode(cipherText);
+            byte[] decrypted = cipher.doFinal(decodedBytes);
+            return new String(decrypted, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new InternalServerException(DATA_DECRYPTION_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/e2i/wemeet/util/encryption/TwoWayEncryption.java
+++ b/src/main/java/com/e2i/wemeet/util/encryption/TwoWayEncryption.java
@@ -1,0 +1,6 @@
+package com.e2i.wemeet.util.encryption;
+
+public interface TwoWayEncryption {
+    String encrypt(String plainText);
+    String decrypt(String cipherText);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
     baseline-on-migrate: true
 
   config:
-    import: sub/application-jwt.yml, sub/application-aws.yml
+    import: sub/application-jwt.yml, sub/application-aws.yml, sub/application-enc.yml
   profiles:
     active: local
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -53,3 +53,4 @@ not.null.preference.meeting.type=preferenceMeetingTypeList는 null일 수 없습
 method.argument.not.valid=잘못된 입력값입니다.
 data.encryption.error=데이터 암호화 과정에서 문제가 발생하였습니다.
 mail.json.parsing.error=메일 변환 중 문제가 발생하였습니다.
+data.decryption.error=데이터 복호화 과정에서 문제가 발생하였습니다.

--- a/src/test/java/com/e2i/wemeet/domain/base/CryptoConverterTest.java
+++ b/src/test/java/com/e2i/wemeet/domain/base/CryptoConverterTest.java
@@ -1,0 +1,50 @@
+package com.e2i.wemeet.domain.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.e2i.wemeet.support.config.AbstractIntegrationTest;
+import com.e2i.wemeet.util.encryption.TwoWayEncryption;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("CryptoConverter 테스트")
+class CryptoConverterTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private CryptoConverter cryptoConverter;
+
+    @Autowired
+    private TwoWayEncryption twoWayEncryption;
+
+    @DisplayName("암호화에 성공한다.")
+    @Test
+    void convertToDatabaseColumn() {
+        // given
+        final String phone = "+821077229911";
+
+        // when
+        String encrypted = cryptoConverter.convertToDatabaseColumn(phone);
+
+        // then
+        assertThat(encrypted).isNotEqualTo(phone);
+    }
+
+    @DisplayName("복호화에 성공한다.")
+    @Test
+    void convertToEntityAttribute() {
+        // given
+        final String phone = "+821077229911";
+        String encrypted = twoWayEncryption.encrypt(phone);
+
+        // when
+        String decrypt = cryptoConverter.convertToEntityAttribute(encrypted);
+
+        // then
+        assertThat(decrypt).isNotEqualTo(encrypted).isEqualTo(phone);
+    }
+
+}

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -76,7 +76,7 @@ public enum MemberFixture {
             .memberCode(this.memberCode)
             .nickname(this.nickname)
             .gender(this.gender)
-            .phoneNumber(EncryptionUtils.hashData(this.phoneNumber))
+            .phoneNumber(this.phoneNumber)
             .collegeInfo(this.collegeInfo)
             .preference(this.preference)
             .mbti(this.mbti)

--- a/src/test/java/com/e2i/wemeet/util/encryption/AdvancedEncryptionStandardTest.java
+++ b/src/test/java/com/e2i/wemeet/util/encryption/AdvancedEncryptionStandardTest.java
@@ -1,0 +1,40 @@
+package com.e2i.wemeet.util.encryption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.e2i.wemeet.support.config.AbstractIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class AdvancedEncryptionStandardTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private TwoWayEncryption twoWayEncryption;
+
+    @DisplayName("암호화에 성공한다.")
+    @ValueSource(strings = {"+821077229911", "+821077229912", "+821077229913", "+821077229914", "+821077229915"})
+    @ParameterizedTest
+    void encrypt(String phone) {
+        // given
+        String encrypted = twoWayEncryption.encrypt(phone);
+
+        // when
+        assertThat(encrypted).isNotEqualTo(phone);
+    }
+
+    @DisplayName("복호화에 성공한다.")
+    @ValueSource(strings = {"+821077229911", "+821077229912", "+821077229913", "+821077229914", "+821077229915"})
+    @ParameterizedTest
+    void decrypt(String phone) {
+        //given
+        String encrypted = twoWayEncryption.encrypt(phone);
+
+        //when
+        String decrypt = twoWayEncryption.decrypt(encrypted);
+
+        //then
+        assertThat(decrypt).isNotEqualTo(encrypted).isEqualTo(phone);
+    }
+}


### PR DESCRIPTION
## Related Issue
#52 

## Description
- 양방향 암호화 모듈을 구현하였습니다.
- JPA AttributeConverter을 사용하여 DB에 데이터 삽입/조회 시 자동으로 암/복호화가 이루어지도록 구현하였습니다.
  - 기존에 Dto나 Fixture에 붙어있던 암호화 동작을 제거하였습니다.

## Screenshots (if appropriate):
1. Member Entity에 plainText를 넣고 DB에 저장하면 DB에 값이 저장되기 전, 자동으로 암호화를 수행합니다. 
![image](https://github.com/SWM-E2I/wemeet-backend/assets/99247279/fb606317-5cc3-4dab-914e-7c40d5c40366)

2. JPA를 사용하여 데이터를 조회할 때도 plainText로 조회하면 암호화된 값으로 조회하기 때문에 비즈니스 코드에서 암/복호화를 신경쓸 필요가 없습니다.
```java
// 내부적으로 "+821099887755" 텍스트를 암호화하여 조회 
memberRepository.findByPhoneNumber("+821099887755")
```
