### PR TITLE
refactor(team): change teamCode format

### DIFF
--- a/src/main/java/com/e2i/wemeet/domain/team/Team.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/Team.java
@@ -33,7 +33,7 @@ public class Team extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long teamId;
 
-    @Column(length = 6, nullable = false)
+    @Column(length = 15, nullable = false)
     private String teamCode;
 
     @Column(nullable = false)

--- a/src/main/java/com/e2i/wemeet/dto/response/team/TeamManagementResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/team/TeamManagementResponseDto.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 
 @Builder
 public record TeamManagementResponseDto(
-    Long managerId,
     String teamCode,
     List<TeamMemberResponseDto> members
 ) {

--- a/src/main/java/com/e2i/wemeet/service/team/TeamServiceImpl.java
+++ b/src/main/java/com/e2i/wemeet/service/team/TeamServiceImpl.java
@@ -63,7 +63,7 @@ public class TeamServiceImpl implements TeamService {
 
         // team 생성
         Team team = teamRepository.save(
-            createTeamRequestDto.toTeamEntity(createTeamCode(TEAM_CODE_LENGTH), member));
+            createTeamRequestDto.toTeamEntity(createTeamCode(TEAM_CODE_LENGTH, memberId), member));
         team.setMember(member);
         member.setRole(Role.MANAGER);
 
@@ -169,7 +169,6 @@ public class TeamServiceImpl implements TeamService {
         members.addAll(findTeamMembers(memberId, team));
 
         return TeamManagementResponseDto.builder()
-            .managerId(memberId)
             .teamCode(team.getTeamCode())
             .members(members)
             .build();
@@ -352,7 +351,7 @@ public class TeamServiceImpl implements TeamService {
         teamPreferenceMeetingTypeRepository.saveAll(preferenceMeetingTypeList);
     }
 
-    private String createTeamCode(int length) {
+    private String createTeamCode(int length, Long managerId) {
         String alphanumeric = "abcdefghijklmnopqrstuvwxyz0123456789";
         StringBuilder sb = new StringBuilder(length);
 
@@ -361,6 +360,6 @@ public class TeamServiceImpl implements TeamService {
             sb.append(alphanumeric.charAt(index));
         }
 
-        return sb.toString();
+        return String.format("%d@%s", managerId, sb);
     }
 }

--- a/src/main/resources/db/migration/V2306211524__create_team.sql
+++ b/src/main/resources/db/migration/V2306211524__create_team.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS `team` (
     `team_id` bigint NOT NULL AUTO_INCREMENT,
-    `team_code` char(6) NOT NULL,
+    `team_code` varchar(15) NOT NULL,
     `member_count` int NOT NULL,
     `is_active` tinyint NOT NULL DEFAULT 0,
     `gender` char(6) NOT NULL,

--- a/src/test/java/com/e2i/wemeet/controller/team/TeamControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/team/TeamControllerTest.java
@@ -211,8 +211,7 @@ class TeamControllerTest extends AbstractUnitTest {
             .isAccepted(true)
             .build();
         TeamManagementResponseDto result = TeamManagementResponseDto.builder()
-            .managerId(1L)
-            .teamCode("ds739d")
+            .teamCode("1@ds739d")
             .members(List.of(member))
             .build();
 
@@ -441,8 +440,6 @@ class TeamControllerTest extends AbstractUnitTest {
                     responseFields(
                         fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
-                        fieldWithPath("data.managerId").type(JsonFieldType.NUMBER)
-                            .description("팀장 아이디"),
                         fieldWithPath("data.teamCode").type(JsonFieldType.STRING)
                             .description("팀 코드"),
                         fieldWithPath("data.members[].memberId").type(JsonFieldType.NUMBER)


### PR DESCRIPTION
## Related Issue
#65 
## Description
teamCode format을 변경하였습니다.
전: `${6자리 임의 코드}`
후: `${managerId}@${6자리 임의 코드}`

## Screenshots (if appropriate):
<img width="387" alt="image" src="https://github.com/SWM-E2I/wemeet-backend/assets/89819254/8be52614-1805-4e79-8780-8e78a6ba7c68">
