### PR TITLE
refactor(member): modify createMember api

### DIFF
--- a/src/main/java/com/e2i/wemeet/controller/member/MemberController.java
+++ b/src/main/java/com/e2i/wemeet/controller/member/MemberController.java
@@ -74,8 +74,7 @@ public class MemberController {
         @RequestBody @Valid ModifyMemberRequestDto requestDto) {
         Long memberId = memberPrincipal.getMemberId();
 
-        List<Code> modifyCode = codeService.findCodeList(requestDto.memberInterestList());
-        memberService.modifyMember(memberId, requestDto, modifyCode);
+        memberService.modifyMember(memberId, requestDto);
 
         return new ResponseDto(ResponseStatus.SUCCESS, "Modify Member Success", null);
     }

--- a/src/main/java/com/e2i/wemeet/controller/member/MemberController.java
+++ b/src/main/java/com/e2i/wemeet/controller/member/MemberController.java
@@ -13,8 +13,8 @@ import com.e2i.wemeet.dto.response.member.MemberPreferenceResponseDto;
 import com.e2i.wemeet.dto.response.member.RoleResponseDto;
 import com.e2i.wemeet.service.code.CodeService;
 import com.e2i.wemeet.service.member.MemberService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -35,20 +35,10 @@ public class MemberController {
 
     @PostMapping
     public ResponseDto<Long> createMember(
-        @RequestBody @Valid CreateMemberRequestDto requestDto) {
-        List<Code> interestCode = new ArrayList<>();
-        if (requestDto.memberInterestList() != null) {
-            interestCode = codeService.findCodeList(requestDto.memberInterestList());
-        }
+        @RequestBody @Valid CreateMemberRequestDto requestDto, HttpServletResponse response) {
+        memberService.createMember(requestDto, response);
 
-        List<Code> preferenceMeetingTypeCode
-            = codeService.findCodeList(requestDto.preferenceMeetingTypeList());
-
-        Long savedMemberId = memberService.createMember(requestDto, interestCode,
-            preferenceMeetingTypeCode);
-
-        return new ResponseDto(ResponseStatus.SUCCESS, "Create Member Success", savedMemberId);
-
+        return new ResponseDto(ResponseStatus.SUCCESS, "Create Member Success", null);
     }
 
     @GetMapping

--- a/src/main/java/com/e2i/wemeet/domain/member/Mbti.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/Mbti.java
@@ -9,7 +9,7 @@ public enum Mbti {
 
     ESTJ, ESTP, ESFJ, ESFP, ENTJ, ENTP, ENFJ, ENFP,
     ISTJ, ISTP, ISFJ, ISFP, INTJ, INTP, INFJ, INFP,
-    NOTHING;
+    XXXX;
 
     @JsonCreator
     public static Mbti findBy(String value) {

--- a/src/main/java/com/e2i/wemeet/dto/request/member/CreateMemberRequestDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/request/member/CreateMemberRequestDto.java
@@ -4,14 +4,12 @@ import com.e2i.wemeet.domain.member.CollegeInfo;
 import com.e2i.wemeet.domain.member.Gender;
 import com.e2i.wemeet.domain.member.Mbti;
 import com.e2i.wemeet.domain.member.Member;
-import com.e2i.wemeet.domain.member.Preference;
 import com.e2i.wemeet.domain.member.Role;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -29,20 +27,12 @@ public record CreateMemberRequestDto(
     @Valid
     CollegeInfoRequestDto collegeInfo,
 
-    @Valid
-    PreferenceRequestDto preference,
-
-    @NotNull(message = "{not.null.preference.meeting.type}")
-    List<String> preferenceMeetingTypeList,
-
     @NotNull(message = "{not.null.mbti}")
     String mbti,
 
     @Nullable
-    String introduction,
+    String introduction
 
-    @Nullable
-    List<String> memberInterestList
 ) {
 
     public Member toMemberEntity(String memberCode) {
@@ -55,14 +45,6 @@ public record CreateMemberRequestDto(
                 .college(collegeInfo.college())
                 .collegeType(collegeInfo.collegeType())
                 .admissionYear(collegeInfo().admissionYear())
-                .build())
-            .preference(Preference.builder()
-                .startPreferenceAdmissionYear(preference.startPreferenceAdmissionYear())
-                .endPreferenceAdmissionYear(preference.endPreferenceAdmissionYear())
-                .drinkingOption(preference.drinkingOption())
-                .sameCollegeState(preference.sameCollegeState())
-                .isAvoidedFriends(preference().isAvoidedFriends())
-                .preferenceMbti(preference.preferenceMbti())
                 .build())
             .mbti(Mbti.findBy(mbti))
             .introduction(introduction)

--- a/src/main/java/com/e2i/wemeet/dto/request/member/ModifyMemberRequestDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/request/member/ModifyMemberRequestDto.java
@@ -2,7 +2,6 @@ package com.e2i.wemeet.dto.request.member;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -12,10 +11,7 @@ public record ModifyMemberRequestDto(
     @NotNull(message = "{not.null.mbti}")
     String mbti,
     @NotBlank(message = "{not.null.introduction}")
-    String introduction,
-
-    @NotNull(message = "{not.null.member.interest}")
-    List<String> memberInterestList
+    String introduction
 ) {
-    
+
 }

--- a/src/main/java/com/e2i/wemeet/dto/response/member/MemberDetailResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/member/MemberDetailResponseDto.java
@@ -3,7 +3,6 @@ package com.e2i.wemeet.dto.response.member;
 import com.e2i.wemeet.domain.member.Gender;
 import com.e2i.wemeet.domain.member.Mbti;
 import com.e2i.wemeet.domain.member.Member;
-import com.e2i.wemeet.domain.memberinterest.MemberInterest;
 import com.e2i.wemeet.domain.profileimage.ProfileImage;
 import java.util.List;
 import lombok.Builder;
@@ -17,18 +16,15 @@ public record MemberDetailResponseDto(
     String collegeType,
     String admissionYear,
     String introduction,
-    List<ProfileImage> profileImageList,
-    List<MemberInterest> memberInterestList
+    List<ProfileImage> profileImageList
 ) {
 
-    public MemberDetailResponseDto(Member member, List<ProfileImage> profileImageList,
-        List<MemberInterest> memberInterestList) {
+    public MemberDetailResponseDto(Member member, List<ProfileImage> profileImageList) {
         this(
             member.getNickname(), member.getGender(), member.getMbti(),
             member.getCollegeInfo().getCollege(),
             member.getCollegeInfo().getCollegeType(),
-            member.getCollegeInfo().getAdmissionYear(), member.getIntroduction(), profileImageList,
-            memberInterestList
+            member.getCollegeInfo().getAdmissionYear(), member.getIntroduction(), profileImageList
         );
     }
 }

--- a/src/main/java/com/e2i/wemeet/service/member/MemberService.java
+++ b/src/main/java/com/e2i/wemeet/service/member/MemberService.java
@@ -8,6 +8,7 @@ import com.e2i.wemeet.dto.response.member.MemberDetailResponseDto;
 import com.e2i.wemeet.dto.response.member.MemberInfoResponseDto;
 import com.e2i.wemeet.dto.response.member.MemberPreferenceResponseDto;
 import com.e2i.wemeet.dto.response.member.RoleResponseDto;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 
 public interface MemberService {
@@ -15,8 +16,7 @@ public interface MemberService {
     /*
      * Member 생성
      */
-    Long createMember(CreateMemberRequestDto requestDto, List<Code> interestCode,
-        List<Code> preferenceMeetingTypeCode);
+    void createMember(CreateMemberRequestDto requestDto, HttpServletResponse response);
 
     /*
      * Member 수정

--- a/src/main/java/com/e2i/wemeet/service/member/MemberService.java
+++ b/src/main/java/com/e2i/wemeet/service/member/MemberService.java
@@ -22,7 +22,7 @@ public interface MemberService {
     /*
      * Member 수정
      */
-    void modifyMember(Long memberId, ModifyMemberRequestDto requestDto, List<Code> modifyCode);
+    void modifyMember(Long memberId, ModifyMemberRequestDto requestDto);
 
     /*
      * 선호 상대 정보 수정

--- a/src/main/java/com/e2i/wemeet/service/member/MemberService.java
+++ b/src/main/java/com/e2i/wemeet/service/member/MemberService.java
@@ -1,6 +1,7 @@
 package com.e2i.wemeet.service.member;
 
 import com.e2i.wemeet.domain.code.Code;
+import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.dto.request.member.CreateMemberRequestDto;
 import com.e2i.wemeet.dto.request.member.ModifyMemberPreferenceRequestDto;
 import com.e2i.wemeet.dto.request.member.ModifyMemberRequestDto;
@@ -16,7 +17,7 @@ public interface MemberService {
     /*
      * Member 생성
      */
-    void createMember(CreateMemberRequestDto requestDto, HttpServletResponse response);
+    Member createMember(CreateMemberRequestDto requestDto, HttpServletResponse response);
 
     /*
      * Member 수정

--- a/src/main/java/com/e2i/wemeet/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/e2i/wemeet/service/member/MemberServiceImpl.java
@@ -1,7 +1,5 @@
 package com.e2i.wemeet.service.member;
 
-import com.e2i.wemeet.config.security.model.MemberPrincipal;
-import com.e2i.wemeet.config.security.token.TokenInjector;
 import com.e2i.wemeet.domain.code.Code;
 import com.e2i.wemeet.domain.member.Mbti;
 import com.e2i.wemeet.domain.member.Member;
@@ -39,22 +37,19 @@ public class MemberServiceImpl implements MemberService {
     private final MemberInterestRepository memberInterestRepository;
     private final MemberPreferenceMeetingTypeRepository memberPreferenceMeetingTypeRepository;
     private final ProfileImageRepository profileImageRepository;
-    private final TokenInjector tokenInjector;
 
     private final SecureRandom random = new SecureRandom();
 
     @Override
     @Transactional
-    public void createMember(CreateMemberRequestDto requestDto, HttpServletResponse response) {
+    public Member createMember(CreateMemberRequestDto requestDto, HttpServletResponse response) {
         memberRepository.findByPhoneNumber(requestDto.phoneNumber())
             .ifPresent(member -> {
                 throw new DuplicatedPhoneNumberException();
             });
 
         String memberCode = createMemberCode();
-        Member member = memberRepository.save(requestDto.toMemberEntity(memberCode));
-
-        tokenInjector.injectToken(response, new MemberPrincipal(member));
+        return memberRepository.save(requestDto.toMemberEntity(memberCode));
     }
 
     @Override

--- a/src/main/java/com/e2i/wemeet/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/e2i/wemeet/service/member/MemberServiceImpl.java
@@ -6,8 +6,6 @@ import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.MemberRepository;
 import com.e2i.wemeet.domain.member.Preference;
 import com.e2i.wemeet.domain.member.Role;
-import com.e2i.wemeet.domain.memberinterest.MemberInterest;
-import com.e2i.wemeet.domain.memberinterest.MemberInterestRepository;
 import com.e2i.wemeet.domain.memberpreferencemeetingtype.MemberPreferenceMeetingType;
 import com.e2i.wemeet.domain.memberpreferencemeetingtype.MemberPreferenceMeetingTypeRepository;
 import com.e2i.wemeet.domain.profileimage.ProfileImage;
@@ -34,7 +32,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
-    private final MemberInterestRepository memberInterestRepository;
     private final MemberPreferenceMeetingTypeRepository memberPreferenceMeetingTypeRepository;
     private final ProfileImageRepository profileImageRepository;
 
@@ -54,16 +51,13 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public void modifyMember(Long memberId, ModifyMemberRequestDto requestDto,
-        List<Code> modifyCode) {
+    public void modifyMember(Long memberId, ModifyMemberRequestDto requestDto) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(MemberNotFoundException::new);
 
         member.modifyNickname(requestDto.nickname());
         member.modifyIntroduction(requestDto.introduction());
         member.modifyMbti(Mbti.findBy(requestDto.mbti()));
-
-        saveMemberInterest(member, modifyCode);
     }
 
 
@@ -93,10 +87,8 @@ public class MemberServiceImpl implements MemberService {
             .orElseThrow(MemberNotFoundException::new);
 
         List<ProfileImage> profileImageList = profileImageRepository.findByMemberMemberId(memberId);
-        List<MemberInterest> memberInterestList = memberInterestRepository.findByMemberMemberId(
-            memberId);
 
-        return new MemberDetailResponseDto(member, profileImageList, memberInterestList);
+        return new MemberDetailResponseDto(member, profileImageList);
     }
 
     @Override
@@ -156,18 +148,6 @@ public class MemberServiceImpl implements MemberService {
 
         memberPreferenceMeetingTypeRepository.deleteAllByMemberMemberId(member.getMemberId());
         memberPreferenceMeetingTypeRepository.saveAll(preferenceMeetingTypeList);
-    }
-
-    private void saveMemberInterest(Member member, List<Code> codeList) {
-        List<MemberInterest> memberInterests = codeList.stream()
-            .map(memberInterestCode -> MemberInterest.builder()
-                .member(member)
-                .code(memberInterestCode)
-                .build())
-            .toList();
-
-        memberInterestRepository.deleteAllByMemberMemberId(member.getMemberId());
-        memberInterestRepository.saveAll(memberInterests);
     }
 
     private String createMemberCode() {

--- a/src/main/java/com/e2i/wemeet/util/aspect/TokenInjectionAspect.java
+++ b/src/main/java/com/e2i/wemeet/util/aspect/TokenInjectionAspect.java
@@ -1,0 +1,36 @@
+package com.e2i.wemeet.util.aspect;
+
+import com.e2i.wemeet.config.security.model.MemberPrincipal;
+import com.e2i.wemeet.config.security.token.TokenInjector;
+import com.e2i.wemeet.domain.member.Member;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Aspect
+public class TokenInjectionAspect {
+
+    private final TokenInjector tokenInjector;
+
+    @AfterReturning(
+        pointcut = "execution(* com.e2i.wemeet.service.member.MemberService.createMember(..))",
+        returning = "member"
+    )
+    public void injectTokenAdvice(JoinPoint joinPoint, Member member) {
+        HttpServletResponse response = getHttpServletResponseFromJoinPointArgs(joinPoint.getArgs());
+
+        tokenInjector.injectToken(response, new MemberPrincipal(member));
+    }
+
+    private HttpServletResponse getHttpServletResponseFromJoinPointArgs(Object[] args) {
+        if (args.length >= 2 && args[1] instanceof HttpServletResponse response) {
+            return response;
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
@@ -3,6 +3,7 @@ package com.e2i.wemeet.controller.member;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -30,6 +31,7 @@ import com.e2i.wemeet.support.fixture.MemberFixture;
 import com.e2i.wemeet.support.fixture.PreferenceFixture;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,8 +58,8 @@ class MemberControllerTest extends AbstractUnitTest {
         CreateMemberRequestDto request = MemberFixture.KAI.createMemberRequestDto();
 
         when(codeService.findCodeList(anyList())).thenReturn(List.of());
-        when(memberService.createMember(any(CreateMemberRequestDto.class), anyList(), anyList()))
-            .thenReturn(1L);
+        doNothing().when(memberService).createMember(any(CreateMemberRequestDto.class), any(
+            HttpServletResponse.class));
 
         // when
         ResultActions perform = mockMvc.perform(post("/v1/member")
@@ -69,10 +71,11 @@ class MemberControllerTest extends AbstractUnitTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value("SUCCESS"))
             .andExpect(jsonPath("$.message").value("Create Member Success"))
-            .andExpect(jsonPath("$.data").exists());
+            .andExpect(jsonPath("$.data").doesNotExist());
 
         // then
-        verify(memberService).createMember(request, List.of(), List.of());
+        verify(memberService).createMember(any(CreateMemberRequestDto.class),
+            any(HttpServletResponse.class));
 
         createMemberWriteRestDocs(perform);
     }
@@ -257,32 +260,14 @@ class MemberControllerTest extends AbstractUnitTest {
                         fieldWithPath("collegeInfo.admissionYear").type(JsonFieldType.STRING)
                             .description("학번"),
                         fieldWithPath("mbti").type(JsonFieldType.STRING).description("본인 MBTI"),
-                        fieldWithPath("preference.startPreferenceAdmissionYear").type(
-                                JsonFieldType.STRING)
-                            .description("선호 시작 학번"),
-                        fieldWithPath("preference.endPreferenceAdmissionYear").type(
-                                JsonFieldType.STRING)
-                            .description("선호 마지막 학번"),
-                        fieldWithPath("preference.sameCollegeState").type(JsonFieldType.STRING)
-                            .description("같은 학교 선호 여부"),
-                        fieldWithPath("preference.drinkingOption").type(JsonFieldType.STRING)
-                            .description("술자리 여부"),
-                        fieldWithPath("preference.isAvoidedFriends").type(JsonFieldType.BOOLEAN)
-                            .description("아는 사람 피하기 여부"),
-                        fieldWithPath("preference.preferenceMbti").type(JsonFieldType.STRING)
-                            .description("선호 MBTI"),
-                        fieldWithPath("preferenceMeetingTypeList").type(
-                            JsonFieldType.ARRAY).description("선호 미팅 유형"),
                         fieldWithPath("introduction").type(JsonFieldType.STRING).optional()
-                            .description("자기 소개"),
-                        fieldWithPath("memberInterestList").type(JsonFieldType.ARRAY).optional()
-                            .description("취미 및 관심사")
+                            .description("자기 소개")
                     ),
                     responseFields(
                         fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
-                        fieldWithPath("data").type(JsonFieldType.NUMBER)
-                            .description("생성된 회원의 memberId")
+                        fieldWithPath("data").type(JsonFieldType.NULL)
+                            .description("data에는 아무 값도 반환되지 않습니다")
                     )
                 ));
     }

--- a/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
@@ -3,7 +3,6 @@ package com.e2i.wemeet.controller.member;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -58,8 +57,9 @@ class MemberControllerTest extends AbstractUnitTest {
         CreateMemberRequestDto request = MemberFixture.KAI.createMemberRequestDto();
 
         when(codeService.findCodeList(anyList())).thenReturn(List.of());
-        doNothing().when(memberService).createMember(any(CreateMemberRequestDto.class), any(
-            HttpServletResponse.class));
+        when(memberService.createMember(any(CreateMemberRequestDto.class), any(
+            HttpServletResponse.class))).thenReturn(
+            MemberFixture.KAI.create());
 
         // when
         ResultActions perform = mockMvc.perform(post("/v1/member")

--- a/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
@@ -178,7 +178,7 @@ class MemberControllerTest extends AbstractUnitTest {
             .andExpect(jsonPath("$.data").doesNotExist());
 
         // then
-        verify(memberService).modifyMember(1L, request, List.of());
+        verify(memberService).modifyMember(1L, request);
         modifyMemberWriteRestDocs(perform);
     }
 
@@ -300,9 +300,7 @@ class MemberControllerTest extends AbstractUnitTest {
                         fieldWithPath("data.introduction").type(JsonFieldType.STRING)
                             .description("자기 소개"),
                         fieldWithPath("data.profileImageList").type(
-                            JsonFieldType.ARRAY).description("프로필 사진 리스트"),
-                        fieldWithPath("data.memberInterestList").type(JsonFieldType.ARRAY)
-                            .description("취미 및 관심사")
+                            JsonFieldType.ARRAY).description("프로필 사진 리스트")
                     )
                 ));
     }
@@ -386,10 +384,7 @@ class MemberControllerTest extends AbstractUnitTest {
                         fieldWithPath("mbti").type(JsonFieldType.STRING)
                             .description("본인 MBTI"),
                         fieldWithPath("introduction").type(JsonFieldType.STRING)
-                            .description("자기 소개"),
-                        fieldWithPath("memberInterestList").type(
-                                JsonFieldType.ARRAY)
-                            .description("취미 및 관심사 (없으면 빈 값)")
+                            .description("자기 소개")
                     ),
                     responseFields(
                         fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),

--- a/src/test/java/com/e2i/wemeet/service/member/MemberServiceTest.java
+++ b/src/test/java/com/e2i/wemeet/service/member/MemberServiceTest.java
@@ -14,8 +14,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.e2i.wemeet.config.security.model.MemberPrincipal;
-import com.e2i.wemeet.config.security.token.TokenInjector;
 import com.e2i.wemeet.domain.code.Code;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.MemberRepository;
@@ -64,9 +62,6 @@ class MemberServiceTest {
     private ProfileImageRepository profileImageRepository;
 
     @Mock
-    private TokenInjector tokenInjector;
-
-    @Mock
     private HttpServletResponse response;
 
     @InjectMocks
@@ -92,8 +87,6 @@ class MemberServiceTest {
         // then
         verify(memberRepository).findByPhoneNumber(anyString());
         verify(memberRepository).save(any(Member.class));
-        verify(tokenInjector).injectToken(any(HttpServletResponse.class),
-            any(MemberPrincipal.class));
     }
 
     @DisplayName("중복된 휴대폰 번호를 가진 회원이 있을 경우 DuplicatedPhoneNumberException이 발생한다.")
@@ -112,8 +105,6 @@ class MemberServiceTest {
         });
         verify(memberRepository).findByPhoneNumber(anyString());
         verify(memberRepository, never()).save(any(Member.class));
-        verify(tokenInjector, never()).injectToken(any(HttpServletResponse.class),
-            any(MemberPrincipal.class));
     }
 
     @DisplayName("회원 수정에 성공한다.")

--- a/src/test/java/com/e2i/wemeet/service/member/MemberServiceTest.java
+++ b/src/test/java/com/e2i/wemeet/service/member/MemberServiceTest.java
@@ -17,8 +17,6 @@ import static org.mockito.Mockito.when;
 import com.e2i.wemeet.domain.code.Code;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.MemberRepository;
-import com.e2i.wemeet.domain.memberinterest.MemberInterest;
-import com.e2i.wemeet.domain.memberinterest.MemberInterestRepository;
 import com.e2i.wemeet.domain.memberpreferencemeetingtype.MemberPreferenceMeetingType;
 import com.e2i.wemeet.domain.memberpreferencemeetingtype.MemberPreferenceMeetingTypeRepository;
 import com.e2i.wemeet.domain.profileimage.ProfileImage;
@@ -51,9 +49,6 @@ class MemberServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
-
-    @Mock
-    private MemberInterestRepository memberInterestRepository;
 
     @Mock
     private MemberPreferenceMeetingTypeRepository memberPreferenceMeetingTypeRepository;
@@ -117,11 +112,10 @@ class MemberServiceTest {
             Optional.ofNullable(member));
 
         // when
-        memberService.modifyMember(memberId, requestDto, interestCode);
+        memberService.modifyMember(memberId, requestDto);
 
         // then
         verify(memberRepository).findById(anyLong());
-        verify(memberInterestRepository).saveAll(anyList());
 
         assertEquals(requestDto.nickname(), member.getNickname());
         assertEquals(requestDto.mbti(), member.getMbti().toString());
@@ -138,11 +132,10 @@ class MemberServiceTest {
 
         // when & then
         assertThrows(MemberNotFoundException.class, () -> {
-            memberService.modifyMember(1L, requestDto, interestCode);
+            memberService.modifyMember(1L, requestDto);
         });
 
         verify(memberRepository).findById(anyLong());
-        verify(memberInterestRepository, never()).saveAll(anyList());
 
         assertNotEquals(requestDto.nickname(), member.getNickname());
         assertNotEquals(requestDto.mbti(), member.getMbti().toString());
@@ -245,13 +238,10 @@ class MemberServiceTest {
     void getMemberDetail_Success() {
         // given
         List<ProfileImage> profileImages = List.of(ProfileImageFixture.MAIN_IMAGE.create());
-        List<MemberInterest> memberInterests = new ArrayList<>();
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         when(profileImageRepository.findByMemberMemberId(memberId))
             .thenReturn(profileImages);
-        when(memberInterestRepository.findByMemberMemberId(memberId))
-            .thenReturn(memberInterests);
 
         // when
         MemberDetailResponseDto result = memberService.getMemberDetail(memberId);
@@ -279,7 +269,6 @@ class MemberServiceTest {
 
         verify(memberRepository).findById(anyLong());
         verify(profileImageRepository, never()).findByMemberMemberId(anyLong());
-        verify(memberInterestRepository, never()).findByMemberMemberId(anyLong());
     }
 
     @DisplayName("선호 상대 정보 조회에 성공한다.")

--- a/src/test/java/com/e2i/wemeet/service/member/MemberServiceTest.java
+++ b/src/test/java/com/e2i/wemeet/service/member/MemberServiceTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.e2i.wemeet.config.security.model.MemberPrincipal;
+import com.e2i.wemeet.config.security.token.TokenInjector;
 import com.e2i.wemeet.domain.code.Code;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.MemberRepository;
@@ -35,6 +37,7 @@ import com.e2i.wemeet.exception.notfound.MemberNotFoundException;
 import com.e2i.wemeet.support.fixture.MemberFixture;
 import com.e2i.wemeet.support.fixture.PreferenceFixture;
 import com.e2i.wemeet.support.fixture.ProfileImageFixture;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -60,6 +63,12 @@ class MemberServiceTest {
     @Mock
     private ProfileImageRepository profileImageRepository;
 
+    @Mock
+    private TokenInjector tokenInjector;
+
+    @Mock
+    private HttpServletResponse response;
+
     @InjectMocks
     private MemberServiceImpl memberService;
 
@@ -76,19 +85,15 @@ class MemberServiceTest {
 
         when(memberRepository.findByPhoneNumber(anyString())).thenReturn(Optional.empty());
         when(memberRepository.save(any(Member.class))).thenReturn(member);
-        when(memberInterestRepository.saveAll(anyList())).thenReturn(new ArrayList<>());
-        when(memberPreferenceMeetingTypeRepository.saveAll(anyList())).thenReturn(
-            new ArrayList<>());
 
         // when
-        memberService.createMember(requestDto, interestCode,
-            preferenceMeetingTypeCode);
+        memberService.createMember(requestDto, response);
 
         // then
         verify(memberRepository).findByPhoneNumber(anyString());
         verify(memberRepository).save(any(Member.class));
-        verify(memberInterestRepository).saveAll(anyList());
-        verify(memberPreferenceMeetingTypeRepository).saveAll(anyList());
+        verify(tokenInjector).injectToken(any(HttpServletResponse.class),
+            any(MemberPrincipal.class));
     }
 
     @DisplayName("중복된 휴대폰 번호를 가진 회원이 있을 경우 DuplicatedPhoneNumberException이 발생한다.")
@@ -103,12 +108,12 @@ class MemberServiceTest {
 
         // when & then
         assertThrows(DuplicatedPhoneNumberException.class, () -> {
-            memberService.createMember(requestDto, interestCode, preferenceMeetingTypeCode);
+            memberService.createMember(requestDto, response);
         });
         verify(memberRepository).findByPhoneNumber(anyString());
         verify(memberRepository, never()).save(any(Member.class));
-        verify(memberInterestRepository, never()).saveAll(anyList());
-        verify(memberPreferenceMeetingTypeRepository, never()).saveAll(anyList());
+        verify(tokenInjector, never()).injectToken(any(HttpServletResponse.class),
+            any(MemberPrincipal.class));
     }
 
     @DisplayName("회원 수정에 성공한다.")

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -112,9 +112,6 @@ public enum MemberFixture {
             .gender(this.gender.toString())
             .phoneNumber(this.phoneNumber)
             .collegeInfo(ANYANG_COLLEGE.createCollegeInfoDto())
-            .preference(GENERAL_PREFERENCE.createPreferenceDto())
-            .preferenceMeetingTypeList(List.of())
-            .memberInterestList(List.of())
             .mbti("ESTJ")
             .introduction("hello!!").build();
     }

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -126,7 +126,6 @@ public enum MemberFixture {
             .admissionYear(this.collegeInfo.getAdmissionYear())
             .introduction(this.introduction)
             .profileImageList(List.of())
-            .memberInterestList(List.of())
             .build();
     }
 
@@ -135,7 +134,6 @@ public enum MemberFixture {
             .nickname("modify nickname")
             .introduction("modify introduction")
             .mbti("ESTJ")
-            .memberInterestList(List.of())
             .build();
     }
 

--- a/src/test/java/com/e2i/wemeet/util/aspect/TokenInjectionAspectTest.java
+++ b/src/test/java/com/e2i/wemeet/util/aspect/TokenInjectionAspectTest.java
@@ -1,0 +1,46 @@
+package com.e2i.wemeet.util.aspect;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.e2i.wemeet.config.security.model.MemberPrincipal;
+import com.e2i.wemeet.config.security.token.TokenInjector;
+import com.e2i.wemeet.domain.member.Member;
+import com.e2i.wemeet.support.fixture.MemberFixture;
+import jakarta.servlet.http.HttpServletResponse;
+import org.aspectj.lang.JoinPoint;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TokenInjectionAspectTest {
+
+    @Mock
+    private TokenInjector tokenInjector;
+
+    @InjectMocks
+    private TokenInjectionAspect tokenInjectionAspect;
+
+    @Test
+    void testInjectTokenAdvice() {
+        // given
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        Member member = MemberFixture.KAI.create();
+
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        Object[] args = new Object[]{member, response};
+        when(joinPoint.getArgs()).thenReturn(args);
+
+        // when
+        tokenInjectionAspect.injectTokenAdvice(joinPoint, member);
+
+        // then
+        verify(tokenInjector).injectToken(any(HttpServletResponse.class),
+            any(MemberPrincipal.class));
+    }
+}


### PR DESCRIPTION
## Related Issue
#68 
## Description
회원 등록 API 수정하였습니다.

* 회원 등록 후 Response Header에 token을 추가하였습니다. -> **AOP** 적용
* 회원 등록 시 선호 정보에 대한 데이터를 받지 않도록 수정하였습니다.
* MVP에서 사용하지 않는 회원 취미 및 관심사 정보를 삭제하였습니다.

## Screenshots (if appropriate):
![image](https://github.com/SWM-E2I/wemeet-backend/assets/89819254/305ee6dc-d962-419c-9e6e-189ad78795bb)
