### PR TITLE
feat(token): add persist login api & change login api response

### DIFF
--- a/src/main/java/com/e2i/wemeet/config/WebConfig.java
+++ b/src/main/java/com/e2i/wemeet/config/WebConfig.java
@@ -3,15 +3,23 @@ package com.e2i.wemeet.config;
 import com.e2i.wemeet.config.aws.AwsS3Config;
 import com.e2i.wemeet.config.aws.AwsSesConfig;
 import com.e2i.wemeet.config.aws.AwsSnsConfig;
+import com.e2i.wemeet.config.resolver.member.MemberIdArgumentResolver;
 import com.e2i.wemeet.util.encryption.AdvancedEncryptionStandard;
+import java.util.List;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @EnableConfigurationProperties({
     AwsSesConfig.class, AwsSnsConfig.class, AwsS3Config.class,
     AdvancedEncryptionStandard.class
 })
 @Configuration
-public class WebConfig {
+public class WebConfig implements WebMvcConfigurer {
 
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new MemberIdArgumentResolver());
+    }
 }

--- a/src/main/java/com/e2i/wemeet/config/aws/AwsBeanConfig.java
+++ b/src/main/java/com/e2i/wemeet/config/aws/AwsBeanConfig.java
@@ -1,0 +1,58 @@
+package com.e2i.wemeet.config.aws;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.sns.SnsClient;
+
+@RequiredArgsConstructor
+@Configuration
+public class AwsBeanConfig {
+
+    private final AwsSesConfig awsSesConfig;
+    private final AwsSnsConfig awsSnsConfig;
+    private final AwsS3Config awsS3Config;
+
+    @Bean
+    public SesClient sesClient() {
+        return SesClient.builder()
+            .credentialsProvider(
+                getAwsCredentials(awsSesConfig.getAccessKey(),
+                    awsSesConfig.getSecretKey())
+            ).region(Region.of(awsSesConfig.getRegion()))
+            .build();
+    }
+
+    @Bean
+    public SnsClient snsClient() {
+        return SnsClient.builder()
+            .credentialsProvider(
+                getAwsCredentials(
+                    awsSnsConfig.getAccessKey(),
+                    awsSnsConfig.getSecretKey())
+            ).region(Region.of(awsSnsConfig.getRegion()))
+            .build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+            .credentialsProvider(
+                getAwsCredentials(awsS3Config.getAccessKey(),
+                    awsS3Config.getSecretKey())
+            ).region(Region.of(awsS3Config.getRegion()))
+            .build();
+    }
+
+    private AwsCredentialsProvider getAwsCredentials(final String accessKeyId,
+        final String secretAccessKey) {
+        AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(accessKeyId,
+            secretAccessKey);
+        return () -> awsBasicCredentials;
+    }
+}

--- a/src/main/java/com/e2i/wemeet/config/resolver/member/MemberId.java
+++ b/src/main/java/com/e2i/wemeet/config/resolver/member/MemberId.java
@@ -1,0 +1,12 @@
+package com.e2i.wemeet.config.resolver.member;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberId {
+
+}

--- a/src/main/java/com/e2i/wemeet/config/resolver/member/MemberIdArgumentResolver.java
+++ b/src/main/java/com/e2i/wemeet/config/resolver/member/MemberIdArgumentResolver.java
@@ -1,0 +1,40 @@
+package com.e2i.wemeet.config.resolver.member;
+
+import com.e2i.wemeet.config.security.model.MemberPrincipal;
+import com.e2i.wemeet.exception.unauthorized.AccessTokenNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/*
+ * MemberId 를 가져오는 ArgumentResolver
+ * */
+@Slf4j
+@Component
+public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasMemberIdAnnotation = parameter.hasParameterAnnotation(MemberId.class);
+        boolean hasLongType = Long.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasLongType && hasMemberIdAnnotation;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        MemberPrincipal principal = (MemberPrincipal) SecurityContextHolder.getContext()
+            .getAuthentication().getPrincipal();
+        if (principal == null || principal.getMemberId() == null) {
+            throw new AccessTokenNotFoundException();
+        }
+
+        return principal.getMemberId();
+    }
+}

--- a/src/main/java/com/e2i/wemeet/config/security/config/SecurityBeanConfig.java
+++ b/src/main/java/com/e2i/wemeet/config/security/config/SecurityBeanConfig.java
@@ -13,7 +13,6 @@ import com.e2i.wemeet.config.security.token.handler.AccessTokenHandler;
 import com.e2i.wemeet.config.security.token.handler.RefreshTokenHandler;
 import com.e2i.wemeet.domain.member.MemberRepository;
 import com.e2i.wemeet.service.credential.sms.SmsCredentialService;
-import com.e2i.wemeet.util.encryption.TwoWayEncryption;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +63,8 @@ public class SecurityBeanConfig {
     @Bean
     public RefreshTokenProcessingFilter refreshTokenProcessingFilter(
         RedisTemplate<String, String> redisTemplate, RefreshTokenHandler refreshTokenHandler,
-        TokenInjector tokenInjector, ObjectMapper objectMapper, AccessTokenHandler accessTokenHandler) {
+        TokenInjector tokenInjector, ObjectMapper objectMapper,
+        AccessTokenHandler accessTokenHandler) {
         return new RefreshTokenProcessingFilter(redisTemplate, refreshTokenHandler, tokenInjector,
             objectMapper, accessTokenHandler);
     }
@@ -105,8 +105,9 @@ public class SecurityBeanConfig {
     // 사용자 로그인 요청 성공시 수행
     @Bean
     public AuthenticationSuccessHandler authenticationSuccessHandler(ObjectMapper objectMapper,
-        TokenInjector tokenInjector) {
-        return new CustomAuthenticationSuccessHandler(objectMapper, tokenInjector);
+        TokenInjector tokenInjector, MemberRepository memberRepository) {
+        return new CustomAuthenticationSuccessHandler(objectMapper, tokenInjector,
+            memberRepository);
     }
 
     /*

--- a/src/main/java/com/e2i/wemeet/config/security/config/SecurityBeanConfig.java
+++ b/src/main/java/com/e2i/wemeet/config/security/config/SecurityBeanConfig.java
@@ -105,9 +105,8 @@ public class SecurityBeanConfig {
     // 사용자 로그인 요청 성공시 수행
     @Bean
     public AuthenticationSuccessHandler authenticationSuccessHandler(ObjectMapper objectMapper,
-        TokenInjector tokenInjector, MemberRepository memberRepository) {
-        return new CustomAuthenticationSuccessHandler(objectMapper, tokenInjector,
-            memberRepository);
+        TokenInjector tokenInjector) {
+        return new CustomAuthenticationSuccessHandler(objectMapper, tokenInjector);
     }
 
     /*

--- a/src/main/java/com/e2i/wemeet/config/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/e2i/wemeet/config/security/handler/CustomAuthenticationSuccessHandler.java
@@ -59,7 +59,11 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
         response.getOutputStream().write(objectMapper.writeValueAsString(result).getBytes());
     }
 
-    private SmsCredentialResponse getSmsCredentialResponse(MemberPrincipal principal) {
+    private SmsCredentialResponse getSmsCredentialResponse(final MemberPrincipal principal) {
+        if (principal.getMemberId() == null) {
+            return SmsCredentialResponse.of(principal, false);
+        }
+
         boolean emailAuthenticated = memberRepository.findById(principal.getMemberId())
             .orElseThrow(MemberNotFoundException::new)
             .isEmailAuthenticated();

--- a/src/main/java/com/e2i/wemeet/config/security/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/e2i/wemeet/config/security/handler/CustomAuthenticationSuccessHandler.java
@@ -4,10 +4,8 @@ import static com.e2i.wemeet.dto.response.ResponseStatus.SUCCESS;
 
 import com.e2i.wemeet.config.security.model.MemberPrincipal;
 import com.e2i.wemeet.config.security.token.TokenInjector;
-import com.e2i.wemeet.domain.member.MemberRepository;
 import com.e2i.wemeet.dto.response.ResponseDto;
 import com.e2i.wemeet.dto.response.credential.SmsCredentialResponse;
-import com.e2i.wemeet.exception.notfound.MemberNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,7 +21,6 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
 
     private final ObjectMapper objectMapper;
     private final TokenInjector tokenInjector;
-    private final MemberRepository memberRepository;
 
     /*
      * SmsCredentialAuthenticationProvider 에서 반환
@@ -50,24 +47,12 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
         throws IOException {
         log.info("Login Request Success - {}", principal.toString());
 
-        SmsCredentialResponse data = getSmsCredentialResponse(principal);
+        SmsCredentialResponse data = SmsCredentialResponse.of(principal);
         ResponseDto result = new ResponseDto(SUCCESS, "인증에 성공하였습니다.", data);
 
         response.setStatus(200);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.getOutputStream().write(objectMapper.writeValueAsString(result).getBytes());
-    }
-
-    private SmsCredentialResponse getSmsCredentialResponse(final MemberPrincipal principal) {
-        if (principal.getMemberId() == null) {
-            return SmsCredentialResponse.of(principal, false);
-        }
-
-        boolean emailAuthenticated = memberRepository.findById(principal.getMemberId())
-            .orElseThrow(MemberNotFoundException::new)
-            .isEmailAuthenticated();
-
-        return SmsCredentialResponse.of(principal, emailAuthenticated);
     }
 }

--- a/src/main/java/com/e2i/wemeet/config/security/model/MemberPrincipal.java
+++ b/src/main/java/com/e2i/wemeet/config/security/model/MemberPrincipal.java
@@ -60,7 +60,7 @@ public class MemberPrincipal implements UserDetails {
 
     public boolean isRegistered() {
         return this.registrationType != null
-            & this.registrationType != RegistrationType.NOT_REGISTERED;
+            && this.registrationType != RegistrationType.NOT_REGISTERED;
     }
 
     public RegistrationType getRegistrationType() {

--- a/src/main/java/com/e2i/wemeet/config/security/model/MemberPrincipal.java
+++ b/src/main/java/com/e2i/wemeet/config/security/model/MemberPrincipal.java
@@ -2,6 +2,7 @@ package com.e2i.wemeet.config.security.model;
 
 import com.e2i.wemeet.config.security.token.Payload;
 import com.e2i.wemeet.domain.member.Member;
+import com.e2i.wemeet.domain.member.RegistrationType;
 import com.e2i.wemeet.domain.member.Role;
 import java.util.Collection;
 import java.util.List;
@@ -10,41 +11,42 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.StringUtils;
 
 /*
-* SecurityContext 에 저장되는 인증 객체
-* */
+ * SecurityContext 에 저장되는 인증 객체
+ * */
 public class MemberPrincipal implements UserDetails {
+
     private final Long memberId;
 
     /*
-    * Authority 는 인가 정책을 적용할 때 필요함
-    * Authentication 객체에 "ROLE_" Prefix 가 붙은 권한 이름을 넘겨줘야 정상 작동하므로 Prefix 를 붙여 저장
-    * RoleHierarchy 적용 -> 각 사용자 당 권한 정보는 한개만 갖도록 구현
-    * */
+     * Authority 는 인가 정책을 적용할 때 필요함
+     * Authentication 객체에 "ROLE_" Prefix 가 붙은 권한 이름을 넘겨줘야 정상 작동하므로 Prefix 를 붙여 저장
+     * RoleHierarchy 적용 -> 각 사용자 당 권한 정보는 한개만 갖도록 구현
+     * */
     private final List<? extends GrantedAuthority> authorities;
-    private final boolean registered;
+    private final RegistrationType registrationType;
 
     public MemberPrincipal() {
         this.memberId = null;
         this.authorities = List.of(Role.GUEST::getRoleAttachedPrefix);
-        this.registered = false;
+        this.registrationType = RegistrationType.NOT_REGISTERED;
     }
 
     public MemberPrincipal(final Member member) {
         this.memberId = member.getMemberId();
         this.authorities = getAuthorities(member.getRole().name());
-        this.registered = true;
+        this.registrationType = RegistrationType.APP;
     }
 
     public MemberPrincipal(final Payload payload) {
         this.memberId = payload.getMemberId();
         this.authorities = getAuthorities(payload.getRole());
-        this.registered = true;
+        this.registrationType = RegistrationType.APP;
     }
 
     public MemberPrincipal(final Long memberId, final String role) {
         this.memberId = memberId;
         this.authorities = getAuthorities(role);
-        this.registered = true;
+        this.registrationType = RegistrationType.APP;
     }
 
     private List<? extends GrantedAuthority> getAuthorities(final String authority) {
@@ -57,7 +59,12 @@ public class MemberPrincipal implements UserDetails {
     }
 
     public boolean isRegistered() {
-        return registered;
+        return this.registrationType != null
+            & this.registrationType != RegistrationType.NOT_REGISTERED;
+    }
+
+    public RegistrationType getRegistrationType() {
+        return registrationType;
     }
 
     @Override
@@ -102,8 +109,8 @@ public class MemberPrincipal implements UserDetails {
                 .map(GrantedAuthority::getAuthority)
                 .toList()
         );
-        final String format = "MemberPrincipal(memberId=%d, role=%s, registered=%s)";
+        final String format = "MemberPrincipal(memberId=%d, role=%s, registrationType=%s)";
 
-        return String.format(format, memberId, role, registered);
+        return String.format(format, memberId, role, registrationType);
     }
 }

--- a/src/main/java/com/e2i/wemeet/config/security/token/handler/AccessTokenHandler.java
+++ b/src/main/java/com/e2i/wemeet/config/security/token/handler/AccessTokenHandler.java
@@ -16,9 +16,9 @@ import org.springframework.util.StringUtils;
 public class AccessTokenHandler extends TokenHandler {
 
     /*
-    * Bearer PREFIX 를 붙여 토큰 생성
-    * - memberId, role 정보 포함
-    * */
+     * Bearer PREFIX 를 붙여 토큰 생성
+     * - memberId, role 정보 포함
+     * */
     @Override
     public String createToken(final Payload payload) {
         Date expirationTime = generateExpirationTime(JwtEnv.ACCESS);
@@ -31,6 +31,13 @@ public class AccessTokenHandler extends TokenHandler {
             .withClaim(Payload.ROLE, payload.getRole())
             .sign(Algorithm.HMAC512(secretKey));
         return ACCESS_PREFIX.concat(token);
+    }
+
+    public Payload extractToken(String accessTokenWithPrefix, boolean verify) {
+        if (verify) {
+            return extractToken(accessTokenWithPrefix);
+        }
+        return extractTokenWithNoVerify(accessTokenWithPrefix);
     }
 
     public Payload extractToken(String accessTokenWithPrefix) {

--- a/src/main/java/com/e2i/wemeet/controller/TokenController.java
+++ b/src/main/java/com/e2i/wemeet/controller/TokenController.java
@@ -1,0 +1,25 @@
+package com.e2i.wemeet.controller;
+
+import com.e2i.wemeet.config.resolver.member.MemberId;
+import com.e2i.wemeet.dto.response.ResponseDto;
+import com.e2i.wemeet.dto.response.ResponseStatus;
+import com.e2i.wemeet.dto.response.persist.PersistResponseDto;
+import com.e2i.wemeet.service.token.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/v1/auth")
+@RestController
+public class TokenController {
+
+    private final TokenService tokenService;
+
+    @GetMapping("/persist")
+    public ResponseDto<PersistResponseDto> persist(@MemberId Long memberId) {
+        PersistResponseDto result = tokenService.persistLogin(memberId);
+        return new ResponseDto<>(ResponseStatus.SUCCESS, "Persist Login Success", result);
+    }
+}

--- a/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
+++ b/src/main/java/com/e2i/wemeet/controller/admin/AdminMemberFixture.java
@@ -10,6 +10,7 @@ import com.e2i.wemeet.domain.member.Gender;
 import com.e2i.wemeet.domain.member.Mbti;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.Preference;
+import com.e2i.wemeet.domain.member.RegistrationType;
 import com.e2i.wemeet.domain.member.Role;
 import java.util.Arrays;
 
@@ -22,9 +23,7 @@ public enum AdminMemberFixture {
         "hello", 100, Role.MANAGER),
     SEYUN("4102", "seyun", Gender.MALE, "+821033445566",
         KU.create(), GENERAL_PREFERENCE.create(), Mbti.ESFJ,
-        "hey", 100, Role.USER)
-
-    ;
+        "hey", 100, Role.USER);
 
     private final String memberCode;
     private final String nickname;
@@ -38,7 +37,8 @@ public enum AdminMemberFixture {
     private final Role role;
 
     AdminMemberFixture(String memberCode, String nickname, Gender gender, String phoneNumber,
-        CollegeInfo collegeInfo, Preference preference, Mbti mbti, String introduction, int credit, Role role) {
+        CollegeInfo collegeInfo, Preference preference, Mbti mbti, String introduction, int credit,
+        Role role) {
         this.memberCode = memberCode;
         this.nickname = nickname;
         this.gender = gender;
@@ -86,6 +86,7 @@ public enum AdminMemberFixture {
             .mbti(this.mbti)
             .introduction(this.introduction)
             .credit(this.credit)
+            .registrationType(RegistrationType.APP)
             .role(this.role);
     }
 

--- a/src/main/java/com/e2i/wemeet/domain/member/Member.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/Member.java
@@ -4,7 +4,6 @@ import com.e2i.wemeet.domain.base.BaseTimeEntity;
 import com.e2i.wemeet.domain.base.CryptoConverter;
 import com.e2i.wemeet.domain.team.Team;
 import com.e2i.wemeet.exception.unauthorized.CreditNotEnoughException;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
@@ -71,7 +70,6 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private RegistrationType registrationType;
 
-    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "teamId")
     private Team team;

--- a/src/main/java/com/e2i/wemeet/domain/member/Member.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/Member.java
@@ -66,6 +66,10 @@ public class Member extends BaseTimeEntity {
     @Column
     private boolean imageAuth;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RegistrationType registrationType;
+
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "teamId")
@@ -78,7 +82,8 @@ public class Member extends BaseTimeEntity {
     @Builder
     public Member(Long memberId, String memberCode, String nickname, Gender gender,
         String phoneNumber, CollegeInfo collegeInfo, Preference preference, Mbti mbti,
-        String introduction, int credit, boolean imageAuth, Team team, Role role) {
+        String introduction, int credit, boolean imageAuth, Team team, Role role,
+        RegistrationType registrationType) {
         this.memberId = memberId;
         this.memberCode = memberCode;
         this.nickname = nickname;
@@ -92,6 +97,7 @@ public class Member extends BaseTimeEntity {
         this.imageAuth = imageAuth;
         this.team = team;
         this.role = role;
+        this.registrationType = registrationType;
     }
 
     public void addCredit(int amount) {

--- a/src/main/java/com/e2i/wemeet/domain/member/Member.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/Member.java
@@ -22,6 +22,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -133,5 +134,9 @@ public class Member extends BaseTimeEntity {
 
     public void setTeam(Team team) {
         this.team = team;
+    }
+
+    public boolean isEmailAuthenticated() {
+        return !StringUtils.hasText(this.collegeInfo.getMail());
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/member/MemberRepository.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/MemberRepository.java
@@ -1,9 +1,10 @@
 package com.e2i.wemeet.domain.member;
 
+import com.e2i.wemeet.domain.member.persist.PersistLoginRepository;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, PersistLoginRepository {
 
     Optional<Member> findByPhoneNumber(String phoneNumber);
 

--- a/src/main/java/com/e2i/wemeet/domain/member/Preference.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/Preference.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,5 +36,14 @@ public class Preference {
         this.drinkingOption = drinkingOption;
         this.isAvoidedFriends = isAvoidedFriends;
         this.preferenceMbti = preferenceMbti;
+    }
+
+    public boolean isComplete() {
+        return
+            StringUtils.hasText(this.startPreferenceAdmissionYear) &&
+                StringUtils.hasText(this.endPreferenceAdmissionYear) &&
+                StringUtils.hasText(this.sameCollegeState) &&
+                StringUtils.hasText(this.drinkingOption) &&
+                StringUtils.hasText(this.preferenceMbti);
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/member/Preference.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/Preference.java
@@ -40,10 +40,10 @@ public class Preference {
 
     public boolean isComplete() {
         return
-            StringUtils.hasText(this.startPreferenceAdmissionYear) &&
-                StringUtils.hasText(this.endPreferenceAdmissionYear) &&
-                StringUtils.hasText(this.sameCollegeState) &&
-                StringUtils.hasText(this.drinkingOption) &&
-                StringUtils.hasText(this.preferenceMbti);
+            StringUtils.hasText(this.startPreferenceAdmissionYear)
+                && StringUtils.hasText(this.endPreferenceAdmissionYear)
+                && StringUtils.hasText(this.sameCollegeState)
+                && StringUtils.hasText(this.drinkingOption)
+                && StringUtils.hasText(this.preferenceMbti);
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/member/RegistrationType.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/RegistrationType.java
@@ -1,0 +1,6 @@
+package com.e2i.wemeet.domain.member;
+
+public enum RegistrationType {
+    WEB,
+    APP;
+}

--- a/src/main/java/com/e2i/wemeet/domain/member/RegistrationType.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/RegistrationType.java
@@ -2,5 +2,6 @@ package com.e2i.wemeet.domain.member;
 
 public enum RegistrationType {
     WEB,
-    APP;
+    APP,
+    NOT_REGISTERED;
 }

--- a/src/main/java/com/e2i/wemeet/domain/member/persist/PersistLoginData.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/persist/PersistLoginData.java
@@ -1,0 +1,46 @@
+package com.e2i.wemeet.domain.member.persist;
+
+import com.e2i.wemeet.domain.member.Preference;
+import com.e2i.wemeet.domain.profileimage.ProfileImage;
+import com.e2i.wemeet.dto.response.persist.PersistResponseDto;
+import org.springframework.util.StringUtils;
+
+public record PersistLoginData(
+    String nickname,
+    String email,
+    Preference preference,
+    ProfileImage profileImage,
+    Long teamId
+) {
+
+    public PersistResponseDto toPersistResponseDto() {
+        return new PersistResponseDto(nickname, emailAuthenticated(), preferenceCompleted(),
+            hasMainProfileImage(), hasCertifiedProfileImage(), hasTeam());
+    }
+
+    private boolean emailAuthenticated() {
+        return StringUtils.hasText(this.email);
+    }
+
+    private boolean preferenceCompleted() {
+        return preference != null && this.preference.isComplete();
+    }
+
+    private boolean hasMainProfileImage() {
+        return profileImage != null && profileImage.getIsMain();
+    }
+
+    private boolean hasCertifiedProfileImage() {
+        return profileImage != null && profileImage.getIsCertified();
+    }
+
+    private boolean hasTeam() {
+        return teamId != null;
+    }
+
+    public String toString() {
+        return "PersistLoginData(nickname=" + this.nickname + ", email=" + this.email
+            + ", preference=" + this.preference + ", profileImage=" + this.profileImage
+            + ", team=" + this.teamId + ")";
+    }
+}

--- a/src/main/java/com/e2i/wemeet/domain/member/persist/PersistLoginRepository.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/persist/PersistLoginRepository.java
@@ -1,0 +1,8 @@
+package com.e2i.wemeet.domain.member.persist;
+
+import com.e2i.wemeet.dto.response.persist.PersistResponseDto;
+
+public interface PersistLoginRepository {
+
+    PersistResponseDto findPersistResponseById(Long memberId);
+}

--- a/src/main/java/com/e2i/wemeet/domain/member/persist/PersistLoginRepositoryImpl.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/persist/PersistLoginRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.e2i.wemeet.domain.member.persist;
+
+import static com.e2i.wemeet.domain.member.QMember.member;
+import static com.e2i.wemeet.domain.profileimage.QProfileImage.profileImage;
+import static com.e2i.wemeet.domain.team.QTeam.team;
+
+import com.e2i.wemeet.dto.response.persist.PersistResponseDto;
+import com.e2i.wemeet.exception.notfound.MemberNotFoundException;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PersistLoginRepositoryImpl implements PersistLoginRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public PersistResponseDto findPersistResponseById(Long memberId) {
+        Optional<PersistLoginData> persistLoginData = Optional.ofNullable(queryFactory
+            .select(Projections.constructor(
+                PersistLoginData.class,
+                member.nickname,
+                member.collegeInfo.mail.as("email"),
+                member.preference,
+                profileImage,
+                team.teamId
+            ))
+            .from(member)
+            .leftJoin(member.team, team)
+            .leftJoin(profileImage)
+            .on(profileImage.member.eq(member).and(profileImage.isMain.eq(true)))
+            .where(member.memberId.eq(memberId))
+            .fetchOne());
+
+        return persistLoginData
+            .orElseThrow(MemberNotFoundException::new)
+            .toPersistResponseDto();
+    }
+}

--- a/src/main/java/com/e2i/wemeet/domain/profileimage/ProfileImage.java
+++ b/src/main/java/com/e2i/wemeet/domain/profileimage/ProfileImage.java
@@ -39,10 +39,10 @@ public class ProfileImage extends BaseTimeEntity {
     private String lowResolutionBlurUrl;
 
     @Column(nullable = false)
-    private boolean isMain;
+    private Boolean isMain;
 
     @Column(nullable = false)
-    private boolean isCertified;
+    private Boolean isCertified;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberId", nullable = false)

--- a/src/main/java/com/e2i/wemeet/domain/team/Team.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/Team.java
@@ -61,7 +61,7 @@ public class Team extends BaseTimeEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberId")
-    private Member member;
+    private Member teamLeader;
 
     @OneToMany(mappedBy = "team")
     private List<Member> members = new ArrayList<>();
@@ -70,7 +70,7 @@ public class Team extends BaseTimeEntity {
     public Team(Long teamId, String teamCode, int memberCount, Gender gender,
         String drinkingOption, String region,
         AdditionalActivity additionalActivity,
-        String introduction, Member member) {
+        String introduction, Member teamLeader) {
         this.teamId = teamId;
         this.teamCode = teamCode;
         this.memberCount = memberCount;
@@ -79,7 +79,7 @@ public class Team extends BaseTimeEntity {
         this.drinkingOption = drinkingOption;
         this.introduction = introduction;
         this.additionalActivity = additionalActivity;
-        this.member = member;
+        setTeamLeader(teamLeader);
     }
 
     public void updateTeam(ModifyTeamRequestDto modifyTeamRequestDto) {
@@ -88,6 +88,12 @@ public class Team extends BaseTimeEntity {
         this.additionalActivity = AdditionalActivity.findBy(
             modifyTeamRequestDto.additionalActivity());
         this.introduction = modifyTeamRequestDto.introduction();
+    }
+
+    public void setTeamLeader(Member teamLeader) {
+        this.teamLeader = teamLeader;
+        this.members.add(teamLeader);
+        teamLeader.setTeam(this);
     }
 
     public void setMember(Member member) {

--- a/src/main/java/com/e2i/wemeet/dto/request/member/CreateMemberRequestDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/request/member/CreateMemberRequestDto.java
@@ -5,6 +5,7 @@ import com.e2i.wemeet.domain.member.Gender;
 import com.e2i.wemeet.domain.member.Mbti;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.Preference;
+import com.e2i.wemeet.domain.member.RegistrationType;
 import com.e2i.wemeet.domain.member.Role;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
@@ -67,6 +68,7 @@ public record CreateMemberRequestDto(
             .mbti(Mbti.findBy(mbti))
             .introduction(introduction)
             .role(Role.USER)
+            .registrationType(RegistrationType.APP)
             .build();
     }
 }

--- a/src/main/java/com/e2i/wemeet/dto/request/team/CreateTeamRequestDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/request/team/CreateTeamRequestDto.java
@@ -43,7 +43,7 @@ public record CreateTeamRequestDto(
             .additionalActivity(AdditionalActivity.findBy(additionalActivity))
             .drinkingOption(drinkingOption)
             .introduction(introduction)
-            .member(member)
+            .teamLeader(member)
             .build();
     }
 

--- a/src/main/java/com/e2i/wemeet/dto/response/credential/SmsCredentialResponse.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/credential/SmsCredentialResponse.java
@@ -1,12 +1,25 @@
 package com.e2i.wemeet.dto.response.credential;
 
+import com.e2i.wemeet.config.security.model.MemberPrincipal;
+import com.e2i.wemeet.domain.member.RegistrationType;
 import java.util.Collection;
 import org.springframework.security.core.GrantedAuthority;
 
 // SMS 인증 응답
 public record SmsCredentialResponse(
-    boolean registered,
+    RegistrationType registrationType,
+    boolean emailAuthenticated,
     Long memberId,
     Collection<? extends GrantedAuthority> role
 ) {
+
+    public static SmsCredentialResponse of(final MemberPrincipal principal,
+        final boolean emailAuthenticated) {
+        return new SmsCredentialResponse(
+            principal.getRegistrationType(),
+            emailAuthenticated,
+            principal.getMemberId(),
+            principal.getAuthorities()
+        );
+    }
 }

--- a/src/main/java/com/e2i/wemeet/dto/response/credential/SmsCredentialResponse.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/credential/SmsCredentialResponse.java
@@ -8,16 +8,13 @@ import org.springframework.security.core.GrantedAuthority;
 // SMS 인증 응답
 public record SmsCredentialResponse(
     RegistrationType registrationType,
-    boolean emailAuthenticated,
     Long memberId,
     Collection<? extends GrantedAuthority> role
 ) {
 
-    public static SmsCredentialResponse of(final MemberPrincipal principal,
-        final boolean emailAuthenticated) {
+    public static SmsCredentialResponse of(final MemberPrincipal principal) {
         return new SmsCredentialResponse(
             principal.getRegistrationType(),
-            emailAuthenticated,
             principal.getMemberId(),
             principal.getAuthorities()
         );

--- a/src/main/java/com/e2i/wemeet/dto/response/persist/PersistResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/persist/PersistResponseDto.java
@@ -1,0 +1,15 @@
+package com.e2i.wemeet.dto.response.persist;
+
+import lombok.Builder;
+
+@Builder
+public record PersistResponseDto(
+    String nickname,
+    boolean emailAuthenticated,
+    boolean preferenceCompleted,
+    boolean hasMainProfileImage,
+    boolean profileImageAuthenticated,
+    boolean hasTeam
+) {
+
+}

--- a/src/main/java/com/e2i/wemeet/exception/ErrorCode.java
+++ b/src/main/java/com/e2i/wemeet/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     JWT_DECODE(40204, "jwt.decode"),
     REFRESH_TOKEN_MISMATCH(40205, "refresh.token.mismatch"),
     REFRESH_TOKEN_NOT_FOUND(40206, "refresh.token.not.found"),
+    ACCESS_TOKEN_NOT_FOUND(40207, "access.token.not.found"),
 
     UNAUTHORIZED(40300, "unauthorized"),
     UNAUTHORIZED_ROLE(40301, "unauthorized.role"),

--- a/src/main/java/com/e2i/wemeet/exception/ErrorCode.java
+++ b/src/main/java/com/e2i/wemeet/exception/ErrorCode.java
@@ -30,47 +30,31 @@ public enum ErrorCode {
     NON_TEAM_MEMBER(40021, "non.team.member"),
 
     NOTFOUND_SMS_CREDENTIAL(40100, "notfound.sms.credential"),
-
     MEMBER_NOT_FOUND(40101, "member.not.found"),
-
     MEMBER_NOT_FOUND_BY_ID(40102, "member.not.found.by.id"),
-
     PROFILE_IMAGE_NOT_FOUND(40103, "profile.image.not.found"),
-
     CODE_NOT_FOUND(40104, "code.not.found"),
     INVITED_MEMBER_NOT_FOUND(40105, "invited.member.not.found"),
     INVITATION_NOT_FOUND(40106, "invitation.not.found"),
 
     ACCESS_TOKEN_EXPIRED(40200, "access.token.expired"),
-
     REFRESH_TOKEN_EXPIRED(40201, "refresh.token.expired"),
-
     JWT_SIGNATURE_MISMATCH(40202, "jwt.signature.mismatch"),
-
     JWT_CLAIM_INCORRECT(40203, "jwt.claim.incorrect"),
-
     JWT_DECODE(40204, "jwt.decode"),
-
     REFRESH_TOKEN_MISMATCH(40205, "refresh.token.mismatch"),
-
     REFRESH_TOKEN_NOT_FOUND(40206, "refresh.token.not.found"),
 
     UNAUTHORIZED(40300, "unauthorized"),
-
     UNAUTHORIZED_ROLE(40301, "unauthorized.role"),
-
     UNAUTHORIZED_ROLE_MANAGER(40302, "unauthorized.role.manager"),
-
     UNAUTHORIZED_ROLE_ADMIN(40303, "unauthorized.role.admin"),
-
     UNAUTHORIZED_CREDIT(40304, "unauthorized.credit"),
-
     UNAUTHORIZED_MEMBER_PROFILE(40305, "unauthorized.member.profile"),
     UNAUTHORIZED_PROFILE_IMAGE(40306, "unauthorized.profile.image"),
     UNAUTHORIZED_UNIV(40307, "unauthorized.univ"),
 
     UNEXPECTED_INTERNAL(50000, "unexpected.internal"),
-
     MISSING_REQUEST_PARAMETER(50001, "missing.request.parameter"),
     DATA_ENCRYPTION_ERROR(50002, "data.encryption.error"),
     MAIL_JSON_PARSING_ERROR(50003, "mail.json.parsing.error"),
@@ -81,9 +65,7 @@ public enum ErrorCode {
     AWS_SES_EMAIL_TRANSFER_ERROR(50200, "aws.ses.email.transfer.error"),
 
     AWS_S3_OBJECT_UPLOAD_ERROR(50300, "aws.s3.object.upload.error"),
-
     AWS_S3_OBJECT_DELETE_ERROR(50301, "aws.s3.object.delete.error"),
-
     AWS_S3_FILE_CONVERSION_ERROR(50302, "aws.s3.file.conversion.error");
 
 

--- a/src/main/java/com/e2i/wemeet/exception/unauthorized/AccessTokenNotFoundException.java
+++ b/src/main/java/com/e2i/wemeet/exception/unauthorized/AccessTokenNotFoundException.java
@@ -1,0 +1,14 @@
+package com.e2i.wemeet.exception.unauthorized;
+
+import com.e2i.wemeet.exception.ErrorCode;
+
+public class AccessTokenNotFoundException extends UnAuthorizedException {
+
+    public AccessTokenNotFoundException() {
+        super(ErrorCode.ACCESS_TOKEN_NOT_FOUND);
+    }
+
+    public AccessTokenNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/e2i/wemeet/service/aws/ses/AwsSesService.java
+++ b/src/main/java/com/e2i/wemeet/service/aws/ses/AwsSesService.java
@@ -31,7 +31,7 @@ import software.amazon.awssdk.services.ses.model.SesException;
 @Service
 public class AwsSesService implements EmailCredentialService {
 
-    private final AwsSesCredentialService awsSesCredentialService;
+    private final SesClient sesClient;
     private final RedisTemplate<String, String> redisTemplate;
     private final MemberRepository memberRepository;
     private static final String TEMPLATE_NAME = "certifyEmailTemplate";
@@ -73,7 +73,6 @@ public class AwsSesService implements EmailCredentialService {
 
 
     private void sendEmail(String email, String message) {
-        SesClient sesClient = awsSesCredentialService.getSesClient();
         SendTemplatedEmailRequest emailRequest = createEmailRequest(email, message);
 
         try {

--- a/src/main/java/com/e2i/wemeet/service/aws/sns/AwsSnsService.java
+++ b/src/main/java/com/e2i/wemeet/service/aws/sns/AwsSnsService.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.services.sns.model.SnsException;
 @Service
 public class AwsSnsService implements SmsCredentialService {
 
-    private final AwsSnsCredentialService awsSnsCredentialService;
+    private final SnsClient snsClient;
     private final RedisTemplate<String, String> redisTemplate;
 
     @Override
@@ -50,7 +50,6 @@ public class AwsSnsService implements SmsCredentialService {
 
 
     private void sendSms(String phoneNumber, String message) {
-        SnsClient snsClient = awsSnsCredentialService.getSnsClient();
         try {
             PublishRequest request = PublishRequest.builder()
                 .message(message)

--- a/src/main/java/com/e2i/wemeet/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/e2i/wemeet/service/member/MemberServiceImpl.java
@@ -115,7 +115,7 @@ public class MemberServiceImpl implements MemberService {
         String profileImageUrl = mainProfileImage.map(ProfileImage::getLowResolutionBasicUrl)
             .orElse(null);
 
-        boolean imageAuth = mainProfileImage.map(ProfileImage::isCertified).orElse(false);
+        boolean imageAuth = mainProfileImage.map(ProfileImage::getIsCertified).orElse(false);
         boolean univAuth = member.getCollegeInfo().getMail() != null;
 
         return MemberInfoResponseDto.builder()

--- a/src/main/java/com/e2i/wemeet/service/team/TeamServiceImpl.java
+++ b/src/main/java/com/e2i/wemeet/service/team/TeamServiceImpl.java
@@ -110,7 +110,7 @@ public class TeamServiceImpl implements TeamService {
             .region(team.getRegion())
             .introduction(team.getIntroduction())
             .additionalActivity(team.getAdditionalActivity())
-            .managerImageAuth(team.getMember().isImageAuth())
+            .managerImageAuth(team.getTeamLeader().isImageAuth())
             .preferenceMeetingTypeList(preferenceMeetingTypeToCodeString(preferenceMeetingTypeList))
             .build();
     }

--- a/src/main/java/com/e2i/wemeet/service/token/TokenService.java
+++ b/src/main/java/com/e2i/wemeet/service/token/TokenService.java
@@ -1,0 +1,8 @@
+package com.e2i.wemeet.service.token;
+
+import com.e2i.wemeet.dto.response.persist.PersistResponseDto;
+
+public interface TokenService {
+
+    PersistResponseDto persistLogin(Long memberId);
+}

--- a/src/main/java/com/e2i/wemeet/service/token/TokenServiceImpl.java
+++ b/src/main/java/com/e2i/wemeet/service/token/TokenServiceImpl.java
@@ -1,0 +1,24 @@
+package com.e2i.wemeet.service.token;
+
+import com.e2i.wemeet.domain.member.persist.PersistLoginRepository;
+import com.e2i.wemeet.dto.response.persist.PersistResponseDto;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TokenServiceImpl implements TokenService {
+
+    private final PersistLoginRepository persistLoginRepository;
+
+    public TokenServiceImpl(
+        @Qualifier("persistLoginRepositoryImpl") PersistLoginRepository persistLoginRepository) {
+        this.persistLoginRepository = persistLoginRepository;
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public PersistResponseDto persistLogin(final Long memberId) {
+        return persistLoginRepository.findPersistResponseById(memberId);
+    }
+}

--- a/src/main/resources/db/migration/V2306210150__create_member.sql
+++ b/src/main/resources/db/migration/V2306210150__create_member.sql
@@ -1,28 +1,33 @@
-CREATE TABLE IF NOT EXISTS `member` (
-    `member_id` bigint NOT NULL AUTO_INCREMENT,
-    `member_code` char(4) NOT NULL,
-    `nickname` varchar(20) NOT NULL,
-    `gender` varchar(6) NOT NULL,
-    `college` varchar(30) NOT NULL,
-    `college_type` varchar(20) NOT NULL,
-    `admission_year` char(2) NOT NULL,
-    `mail`  varchar(60),
-    `phone_number` char(60) NOT NULL,
-    `mbti` varchar(7) NOT NULL,
-    `introduction` varchar(100),
+CREATE TABLE IF NOT EXISTS `member`
+(
+    `member_id`                       bigint      NOT NULL AUTO_INCREMENT,
+    `member_code`                     char(4)     NOT NULL,
+    `nickname`                        varchar(20) NOT NULL,
+    `gender`                          varchar(6)  NOT NULL,
+    `college`                         varchar(30) NOT NULL,
+    `college_type`                    varchar(20) NOT NULL,
+    `admission_year`                  char(2)     NOT NULL,
+    `mail`                            varchar(60),
+    `phone_number`                    char(60)    NOT NULL,
+    `mbti`                            varchar(7)  NOT NULL,
+    `introduction`                    varchar(100),
     `start_preference_admission_year` char(2),
-    `end_preference_admission_year` char(2),
-    `credit` int NOT NULL,
-    `same_college_state` char(2),
-    `drinking_option` char(2),
-    `is_avoided_friends` tinyint,
-    `preference_mbti` char(4),
-    `image_auth` tinyint DEFAULT 0,
-    `created_at` datetime(6),
-    `modified_at` datetime(6),
-    `role` varchar(8),
+    `end_preference_admission_year`   char(2),
+    `credit`                          int         NOT NULL,
+    `same_college_state`              char(2),
+    `drinking_option`                 char(2),
+    `is_avoided_friends`              tinyint,
+    `preference_mbti`                 char(4),
+    `image_auth`                      tinyint DEFAULT 0,
+    `created_at`                      datetime(6),
+    `modified_at`                     datetime(6),
+    `role`                            varchar(8),
     PRIMARY KEY (`member_id`),
     UNIQUE KEY `member_mail` (`mail`),
-    UNIQUE KEY `member_phone_number` (`phone_number`))
+    UNIQUE KEY `member_phone_number` (`phone_number`)
+)
     ENGINE = InnoDB
-    DEFAULT CHARACTER SET=utf8mb4;
+    DEFAULT CHARACTER SET = utf8mb4;
+
+ALTER TABLE `member`
+    ADD `registration_type` varchar(15) NOT NULL AFTER `credit`;

--- a/src/main/resources/db/migration/V2306211524__create_team.sql
+++ b/src/main/resources/db/migration/V2306211524__create_team.sql
@@ -1,21 +1,25 @@
-CREATE TABLE IF NOT EXISTS `team` (
-    `team_id` bigint NOT NULL AUTO_INCREMENT,
-    `team_code` char(6) NOT NULL,
-    `member_count` int NOT NULL,
-    `is_active` tinyint NOT NULL DEFAULT 0,
-    `gender` char(6) NOT NULL,
-    `region` varchar(20) NOT NULL,
-    `drinking_option` char(2) NOT NULL,
+CREATE TABLE IF NOT EXISTS `team`
+(
+    `team_id`             bigint      NOT NULL AUTO_INCREMENT,
+    `team_code`           char(8)     NOT NULL,
+    `member_count`        int         NOT NULL,
+    `is_active`           tinyint     NOT NULL DEFAULT 0,
+    `gender`              char(6)     NOT NULL,
+    `region`              varchar(20) NOT NULL,
+    `drinking_option`     char(2)     NOT NULL,
     `additional_activity` varchar(20),
-    `introduction` varchar(100),
-    `created_at` datetime(6),
-    `modified_at` datetime(6),
-    `member_id` bigint NOT NULL,
+    `introduction`        varchar(100),
+    `created_at`          datetime(6),
+    `modified_at`         datetime(6),
+    `member_id`           bigint      NOT NULL,
     PRIMARY KEY (`team_id`),
-    FOREIGN KEY (`member_id`) REFERENCES `member` (`member_id`) ON DELETE CASCADE)
+    FOREIGN KEY (`member_id`) REFERENCES `member` (`member_id`) ON DELETE CASCADE
+)
     ENGINE = InnoDB
-    DEFAULT CHARACTER SET=utf8mb4;
+    DEFAULT CHARACTER SET = utf8mb4;
 
-ALTER TABLE `member` ADD `team_id` bigint;
-ALTER TABLE `member` ADD FOREIGN KEY (`team_id`) REFERENCES team (`team_id`) ON DELETE SET NULL;
+ALTER TABLE `member`
+    ADD `team_id` bigint;
+ALTER TABLE `member`
+    ADD FOREIGN KEY (`team_id`) REFERENCES team (`team_id`) ON DELETE SET NULL;
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -17,6 +17,7 @@ jwt.claim.incorrect=토큰 Claim 정보가 올바르지 않습니다.
 jwt.decode=토큰을 파싱하는데 실패했습니다.
 refresh.token.mismatch=해당 유저에게 발급했던 RefreshToken과 값이 일치하지 않습니다.
 refresh.token.not.found=요청 정보에서 RefreshToken을 찾을 수 없습니다.
+access.token.not.found=요청 정보에서 AccessToken을 찾을 수 없습니다.
 unauthorized=요청에 대한 실행 권한이 없습니다.
 unauthorized.role=해당 유저는 본 요청을 수행할 권한이 없습니다.
 unauthorized.role.manager=해당 유저는 매니저 권한이 없습니다.

--- a/src/test/java/com/e2i/wemeet/config/security/filter/SMSLoginProcessingFilterTest.java
+++ b/src/test/java/com/e2i/wemeet/config/security/filter/SMSLoginProcessingFilterTest.java
@@ -155,8 +155,6 @@ class SMSLoginProcessingFilterTest extends AbstractIntegrationTest {
                         fieldWithPath("data.registrationType").type(JsonFieldType.STRING)
                             .description("사용자 회원 가입 종류를 반환 합니다. "
                                 + "(APP-앱, WEB-웹, NOT_REGISTERED-미가입)"),
-                        fieldWithPath("data.emailAuthenticated").type(JsonFieldType.BOOLEAN)
-                            .description("이메일 인증 여부"),
                         fieldWithPath("data.memberId")
                             .description("회원 아이디"),
                         fieldWithPath("data.role[].authority").type(JsonFieldType.STRING)

--- a/src/test/java/com/e2i/wemeet/config/security/filter/SMSLoginProcessingFilterTest.java
+++ b/src/test/java/com/e2i/wemeet/config/security/filter/SMSLoginProcessingFilterTest.java
@@ -152,7 +152,7 @@ class SMSLoginProcessingFilterTest extends AbstractIntegrationTest {
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                         fieldWithPath("data").type(JsonFieldType.OBJECT)
                             .description("회원 가입이 되어있지 않은 사용자의 경우 null로 채워서 반환됨"),
-                        fieldWithPath("data.registered").type(JsonFieldType.BOOLEAN)
+                        fieldWithPath("data.registrationType").type(JsonFieldType.BOOLEAN)
                             .description("회원 가입 여부"),
                         fieldWithPath("data.memberId").description("회원 아이디"),
                         fieldWithPath("data.role[].authority").type(JsonFieldType.STRING)

--- a/src/test/java/com/e2i/wemeet/config/security/filter/SMSLoginProcessingFilterTest.java
+++ b/src/test/java/com/e2i/wemeet/config/security/filter/SMSLoginProcessingFilterTest.java
@@ -152,9 +152,13 @@ class SMSLoginProcessingFilterTest extends AbstractIntegrationTest {
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                         fieldWithPath("data").type(JsonFieldType.OBJECT)
                             .description("회원 가입이 되어있지 않은 사용자의 경우 null로 채워서 반환됨"),
-                        fieldWithPath("data.registrationType").type(JsonFieldType.BOOLEAN)
-                            .description("회원 가입 여부"),
-                        fieldWithPath("data.memberId").description("회원 아이디"),
+                        fieldWithPath("data.registrationType").type(JsonFieldType.STRING)
+                            .description("사용자 회원 가입 종류를 반환 합니다. "
+                                + "(APP-앱, WEB-웹, NOT_REGISTERED-미가입)"),
+                        fieldWithPath("data.emailAuthenticated").type(JsonFieldType.BOOLEAN)
+                            .description("이메일 인증 여부"),
+                        fieldWithPath("data.memberId")
+                            .description("회원 아이디"),
                         fieldWithPath("data.role[].authority").type(JsonFieldType.STRING)
                             .description("회원 권한")
                     )

--- a/src/test/java/com/e2i/wemeet/config/security/manager/CreditAuthorizationManagerTest.java
+++ b/src/test/java/com/e2i/wemeet/config/security/manager/CreditAuthorizationManagerTest.java
@@ -8,6 +8,7 @@ import com.e2i.wemeet.config.security.token.Payload;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.MemberRepository;
 import com.e2i.wemeet.domain.member.Role;
+import com.e2i.wemeet.dto.response.persist.PersistResponseDto;
 import com.e2i.wemeet.exception.unauthorized.CreditNotEnoughException;
 import com.e2i.wemeet.exception.unauthorized.UnAuthorizedRoleException;
 import java.lang.annotation.Annotation;
@@ -304,6 +305,11 @@ class CreditAuthorizationManagerTest {
 
         @Override
         public Page<Member> findAll(Pageable pageable) {
+            return null;
+        }
+
+        @Override
+        public PersistResponseDto findPersistResponseById(Long memberId) {
             return null;
         }
     }

--- a/src/test/java/com/e2i/wemeet/controller/TokenControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/TokenControllerTest.java
@@ -1,0 +1,88 @@
+package com.e2i.wemeet.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.e2i.wemeet.dto.response.persist.PersistResponseDto;
+import com.e2i.wemeet.service.token.TokenService;
+import com.e2i.wemeet.support.config.AbstractControllerUnitTest;
+import com.e2i.wemeet.support.config.WithCustomMockUser;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(TokenController.class)
+class TokenControllerTest extends AbstractControllerUnitTest {
+
+    @MockBean
+    private TokenService tokenService;
+
+    @WithCustomMockUser
+    @DisplayName("Persist Login 요청을 통해 유저의 상태 정보를 반환받는다.")
+    @Test
+    void persist() throws Exception {
+        // given
+        given(tokenService.persistLogin(1L)).willReturn(
+            PersistResponseDto.builder()
+                .nickname("kai")
+                .hasTeam(true)
+                .emailAuthenticated(true)
+                .profileImageAuthenticated(false)
+                .hasMainProfileImage(true)
+                .preferenceCompleted(true)
+                .build()
+        );
+
+        // when
+        ResultActions perform = mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/v1/auth/persist")
+                .header("Authorization", "Bearer " + "token")
+        );
+
+        // then
+        perform.andExpectAll(
+            status().isOk(),
+            jsonPath("$.status").value("SUCCESS"),
+            jsonPath("$.message").value("Persist Login Success"),
+            jsonPath("$.data").isNotEmpty()
+        );
+
+        perform
+            .andDo(
+                MockMvcRestDocumentationWrapper.document("PERSIST LOGIN 요청",
+                    ResourceSnippetParameters.builder()
+                        .tag("Persist Login API")
+                        .summary("AccessToken 을 통해 유저의 상태 정보를 반환합니다.")
+                        .description(
+                            """
+                                   AccessToken 을 통해 유저의 상태 정보를 반환합니다.
+                                """),
+                    responseFields(
+                        fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                        fieldWithPath("data.nickname").type(JsonFieldType.STRING)
+                            .description("사용자의 닉네임을 반환합니다."),
+                        fieldWithPath("data.emailAuthenticated").type(JsonFieldType.BOOLEAN)
+                            .description("이메일 인증 여부를 반환합니다."),
+                        fieldWithPath("data.preferenceCompleted").type(JsonFieldType.BOOLEAN)
+                            .description("선호도 조사 여부를 반환합니다."),
+                        fieldWithPath("data.hasMainProfileImage").type(JsonFieldType.BOOLEAN)
+                            .description("프로필 이미지의 등록 여부를 반환합니다."),
+                        fieldWithPath("data.profileImageAuthenticated").type(JsonFieldType.BOOLEAN)
+                            .description("프로필 이미지 인증 여부를 반환합니다."),
+                        fieldWithPath("data.hasTeam").type(JsonFieldType.BOOLEAN)
+                            .description("팀의 존재 여부를 반환합니다.")
+                    )
+                ));
+    }
+}

--- a/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
@@ -30,6 +30,7 @@ import com.e2i.wemeet.support.fixture.MemberFixture;
 import com.e2i.wemeet.support.fixture.PreferenceFixture;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(MemberController.class)
-class MemberControllerTestController extends AbstractControllerUnitTest {
+class MemberControllerTest extends AbstractControllerUnitTest {
 
     @MockBean
     private MemberService memberService;
@@ -56,8 +57,9 @@ class MemberControllerTestController extends AbstractControllerUnitTest {
         CreateMemberRequestDto request = MemberFixture.KAI.createMemberRequestDto();
 
         when(codeService.findCodeList(anyList())).thenReturn(List.of());
-        when(memberService.createMember(any(CreateMemberRequestDto.class), anyList(), anyList()))
-            .thenReturn(1L);
+        when(memberService.createMember(any(CreateMemberRequestDto.class), any(
+            HttpServletResponse.class))).thenReturn(
+            MemberFixture.KAI.create());
 
         // when
         ResultActions perform = mockMvc.perform(post("/v1/member")
@@ -69,10 +71,11 @@ class MemberControllerTestController extends AbstractControllerUnitTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.status").value("SUCCESS"))
             .andExpect(jsonPath("$.message").value("Create Member Success"))
-            .andExpect(jsonPath("$.data").exists());
+            .andExpect(jsonPath("$.data").doesNotExist());
 
         // then
-        verify(memberService).createMember(request, List.of(), List.of());
+        verify(memberService).createMember(any(CreateMemberRequestDto.class),
+            any(HttpServletResponse.class));
 
         createMemberWriteRestDocs(perform);
     }
@@ -175,7 +178,7 @@ class MemberControllerTestController extends AbstractControllerUnitTest {
             .andExpect(jsonPath("$.data").doesNotExist());
 
         // then
-        verify(memberService).modifyMember(1L, request, List.of());
+        verify(memberService).modifyMember(1L, request);
         modifyMemberWriteRestDocs(perform);
     }
 
@@ -257,32 +260,14 @@ class MemberControllerTestController extends AbstractControllerUnitTest {
                         fieldWithPath("collegeInfo.admissionYear").type(JsonFieldType.STRING)
                             .description("학번"),
                         fieldWithPath("mbti").type(JsonFieldType.STRING).description("본인 MBTI"),
-                        fieldWithPath("preference.startPreferenceAdmissionYear").type(
-                                JsonFieldType.STRING)
-                            .description("선호 시작 학번"),
-                        fieldWithPath("preference.endPreferenceAdmissionYear").type(
-                                JsonFieldType.STRING)
-                            .description("선호 마지막 학번"),
-                        fieldWithPath("preference.sameCollegeState").type(JsonFieldType.STRING)
-                            .description("같은 학교 선호 여부"),
-                        fieldWithPath("preference.drinkingOption").type(JsonFieldType.STRING)
-                            .description("술자리 여부"),
-                        fieldWithPath("preference.isAvoidedFriends").type(JsonFieldType.BOOLEAN)
-                            .description("아는 사람 피하기 여부"),
-                        fieldWithPath("preference.preferenceMbti").type(JsonFieldType.STRING)
-                            .description("선호 MBTI"),
-                        fieldWithPath("preferenceMeetingTypeList").type(
-                            JsonFieldType.ARRAY).description("선호 미팅 유형"),
                         fieldWithPath("introduction").type(JsonFieldType.STRING).optional()
-                            .description("자기 소개"),
-                        fieldWithPath("memberInterestList").type(JsonFieldType.ARRAY).optional()
-                            .description("취미 및 관심사")
+                            .description("자기 소개")
                     ),
                     responseFields(
                         fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
-                        fieldWithPath("data").type(JsonFieldType.NUMBER)
-                            .description("생성된 회원의 memberId")
+                        fieldWithPath("data").type(JsonFieldType.NULL)
+                            .description("data에는 아무 값도 반환되지 않습니다")
                     )
                 ));
     }
@@ -315,9 +300,7 @@ class MemberControllerTestController extends AbstractControllerUnitTest {
                         fieldWithPath("data.introduction").type(JsonFieldType.STRING)
                             .description("자기 소개"),
                         fieldWithPath("data.profileImageList").type(
-                            JsonFieldType.ARRAY).description("프로필 사진 리스트"),
-                        fieldWithPath("data.memberInterestList").type(JsonFieldType.ARRAY)
-                            .description("취미 및 관심사")
+                            JsonFieldType.ARRAY).description("프로필 사진 리스트")
                     )
                 ));
     }
@@ -401,10 +384,7 @@ class MemberControllerTestController extends AbstractControllerUnitTest {
                         fieldWithPath("mbti").type(JsonFieldType.STRING)
                             .description("본인 MBTI"),
                         fieldWithPath("introduction").type(JsonFieldType.STRING)
-                            .description("자기 소개"),
-                        fieldWithPath("memberInterestList").type(
-                                JsonFieldType.ARRAY)
-                            .description("취미 및 관심사 (없으면 빈 값)")
+                            .description("자기 소개")
                     ),
                     responseFields(
                         fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),

--- a/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTestController.java
+++ b/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTestController.java
@@ -24,7 +24,7 @@ import com.e2i.wemeet.dto.response.member.MemberPreferenceResponseDto;
 import com.e2i.wemeet.dto.response.member.RoleResponseDto;
 import com.e2i.wemeet.service.code.CodeService;
 import com.e2i.wemeet.service.member.MemberService;
-import com.e2i.wemeet.support.config.AbstractUnitTest;
+import com.e2i.wemeet.support.config.AbstractControllerUnitTest;
 import com.e2i.wemeet.support.config.WithCustomMockUser;
 import com.e2i.wemeet.support.fixture.MemberFixture;
 import com.e2i.wemeet.support.fixture.PreferenceFixture;
@@ -40,7 +40,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(MemberController.class)
-class MemberControllerTest extends AbstractUnitTest {
+class MemberControllerTestController extends AbstractControllerUnitTest {
 
     @MockBean
     private MemberService memberService;

--- a/src/test/java/com/e2i/wemeet/controller/team/TeamControllerTestController.java
+++ b/src/test/java/com/e2i/wemeet/controller/team/TeamControllerTestController.java
@@ -29,7 +29,7 @@ import com.e2i.wemeet.dto.response.team.TeamManagementResponseDto;
 import com.e2i.wemeet.dto.response.team.TeamMemberResponseDto;
 import com.e2i.wemeet.service.code.CodeService;
 import com.e2i.wemeet.service.team.TeamService;
-import com.e2i.wemeet.support.config.AbstractUnitTest;
+import com.e2i.wemeet.support.config.AbstractControllerUnitTest;
 import com.e2i.wemeet.support.config.WithCustomMockUser;
 import com.e2i.wemeet.support.fixture.MemberFixture;
 import com.e2i.wemeet.support.fixture.TeamFixture;
@@ -46,7 +46,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(TeamController.class)
-class TeamControllerTest extends AbstractUnitTest {
+class TeamControllerTestController extends AbstractControllerUnitTest {
 
     @MockBean
     private TeamService teamService;

--- a/src/test/java/com/e2i/wemeet/domain/member/PersistLoginRepositoryImplTest.java
+++ b/src/test/java/com/e2i/wemeet/domain/member/PersistLoginRepositoryImplTest.java
@@ -1,0 +1,135 @@
+package com.e2i.wemeet.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.e2i.wemeet.domain.profileimage.ProfileImage;
+import com.e2i.wemeet.domain.profileimage.ProfileImageRepository;
+import com.e2i.wemeet.domain.team.TeamRepository;
+import com.e2i.wemeet.dto.response.persist.PersistResponseDto;
+import com.e2i.wemeet.support.config.RepositoryTest;
+import com.e2i.wemeet.support.fixture.MemberFixture;
+import com.e2i.wemeet.support.fixture.ProfileImageFixture;
+import com.e2i.wemeet.support.fixture.TeamFixture;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RepositoryTest
+class PersistLoginRepositoryImplTest {
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private ProfileImageRepository profileImageRepository;
+
+    @DisplayName("사용자의 persist 정보를 가져오는데 성공한다.")
+    @Test
+    void persistLogin() {
+        // given
+        Member kai = memberRepository.save(MemberFixture.KAI.create());
+        teamRepository.save(TeamFixture.HONGDAE_TEAM.create(kai));
+
+        ProfileImage kaiProfile = ProfileImageFixture.MAIN_IMAGE.create(kai);
+        profileImageRepository.save(kaiProfile);
+        entityManager.flush();
+
+        // when
+        PersistResponseDto persistResponseDto = memberRepository.findPersistResponseById(
+            kai.getMemberId());
+
+        // then
+        assertAll(
+            () -> assertThat(persistResponseDto).isNotNull(),
+            () -> assertThat(persistResponseDto.emailAuthenticated()).isTrue(),
+            () -> assertThat(persistResponseDto.hasTeam()).isTrue(),
+            () -> assertThat(persistResponseDto.hasMainProfileImage()).isTrue(),
+            () -> assertThat(persistResponseDto.nickname()).isEqualTo(
+                MemberFixture.KAI.getNickname()),
+            () -> assertThat(persistResponseDto.preferenceCompleted()).isTrue(),
+            () -> assertThat(persistResponseDto.profileImageAuthenticated()).isTrue()
+        );
+    }
+
+    @DisplayName("사용자가 이메일 인증을 진행하지 않았을 경우, emailAuthenticated 는 false 를 반환한다.")
+    @Test
+    void persistLoginNoEmail() {
+        // given
+        CollegeInfo collegeInfo = CollegeInfo.builder()
+            .college("한국대학교")
+            .collegeType("이공계열")
+            .admissionYear("17")
+            .mail(null)
+            .build();
+        Member kai = memberRepository.save(MemberFixture.KAI.create_college(collegeInfo));
+
+        // when
+        PersistResponseDto persistResponseDto = memberRepository.findPersistResponseById(
+            kai.getMemberId());
+
+        // then
+        assertAll(
+            () -> assertThat(persistResponseDto).isNotNull(),
+            () -> assertThat(persistResponseDto.hasTeam()).isFalse()
+        );
+    }
+
+    @DisplayName("사용자가 Team 이 없을 경우, hasTeam 은 false 를 반환한다.")
+    @Test
+    void persistLoginNoTeam() {
+        // given
+        Member kai = memberRepository.save(MemberFixture.KAI.create());
+
+        // when
+        PersistResponseDto persistResponseDto = memberRepository.findPersistResponseById(
+            kai.getMemberId());
+
+        // then
+        assertAll(
+            () -> assertThat(persistResponseDto).isNotNull(),
+            () -> assertThat(persistResponseDto.hasTeam()).isFalse()
+        );
+    }
+
+    @DisplayName("사용자가 ProfileImage 가 없을 경우, hasMainProfileImage 는 false 를 반환한다.")
+    @Test
+    void persistLoginNoProfile() {
+        // given
+        Member kai = memberRepository.save(MemberFixture.KAI.create());
+
+        // when
+        PersistResponseDto persistResponseDto = memberRepository.findPersistResponseById(
+            kai.getMemberId());
+
+        // then
+        assertAll(
+            () -> assertThat(persistResponseDto).isNotNull(),
+            () -> assertThat(persistResponseDto.hasMainProfileImage()).isFalse(),
+            () -> assertThat(persistResponseDto.profileImageAuthenticated()).isFalse()
+        );
+    }
+
+    @DisplayName("사용자가 선호 상대에 대한 정보를 입력하지 않았을 경우, preferenceCompleted 는 false 를 반환한다.")
+    @Test
+    void persistLoginNoPreference() {
+        // given
+        Member kai = memberRepository.save(MemberFixture.KAI.create_preference(null));
+
+        // when
+        PersistResponseDto persistResponseDto = memberRepository.findPersistResponseById(
+            kai.getMemberId());
+
+        // then
+        assertAll(
+            () -> assertThat(persistResponseDto).isNotNull(),
+            () -> assertThat(persistResponseDto.preferenceCompleted()).isFalse()
+        );
+    }
+}

--- a/src/test/java/com/e2i/wemeet/domain/member/PersistLoginRepositoryImplTest.java
+++ b/src/test/java/com/e2i/wemeet/domain/member/PersistLoginRepositoryImplTest.java
@@ -44,7 +44,6 @@ class PersistLoginRepositoryImplTest {
         // when
         PersistResponseDto persistResponseDto = memberRepository.findPersistResponseById(
             kai.getMemberId());
-        System.out.println("persistResponseDto = " + persistResponseDto);
 
         // then
         assertAll(

--- a/src/test/java/com/e2i/wemeet/service/team/TeamServiceTest.java
+++ b/src/test/java/com/e2i/wemeet/service/team/TeamServiceTest.java
@@ -235,7 +235,7 @@ class TeamServiceTest {
         assertEquals(result.drinkingOption(), team.getDrinkingOption());
         assertEquals(result.additionalActivity(), team.getAdditionalActivity());
         assertEquals(result.introduction(), team.getIntroduction());
-        assertEquals(result.managerImageAuth(), team.getMember().isImageAuth());
+        assertEquals(result.managerImageAuth(), team.getTeamLeader().isImageAuth());
 
         // after
         member.setTeam(null);

--- a/src/test/java/com/e2i/wemeet/service/token/TokenServiceImplTest.java
+++ b/src/test/java/com/e2i/wemeet/service/token/TokenServiceImplTest.java
@@ -1,0 +1,74 @@
+package com.e2i.wemeet.service.token;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.e2i.wemeet.domain.member.persist.PersistLoginRepository;
+import com.e2i.wemeet.dto.response.persist.PersistResponseDto;
+import com.e2i.wemeet.exception.unauthorized.AccessTokenNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TokenServiceImplTest {
+
+    private TokenService tokenService;
+
+    @BeforeEach
+    void setUp() {
+        PersistLoginRepositoryRepositoryStub repositoryStub = new PersistLoginRepositoryRepositoryStub();
+        tokenService = new TokenServiceImpl(repositoryStub);
+    }
+
+    @DisplayName("persist 정보를 가져오는데 성공한다.")
+    @Test
+    void persistLoginSuccess() {
+        // given
+        final Long memberId = 1L;
+
+        // when
+        PersistResponseDto persistResponseDto = tokenService.persistLogin(memberId);
+
+        // then
+        assertAll(
+            () -> assertThat(persistResponseDto).isNotNull(),
+            () -> assertThat(persistResponseDto.nickname()).isEqualTo("kai"),
+            () -> assertThat(persistResponseDto.emailAuthenticated()).isTrue(),
+            () -> assertThat(persistResponseDto.profileImageAuthenticated()).isFalse(),
+            () -> assertThat(persistResponseDto.hasMainProfileImage()).isTrue(),
+            () -> assertThat(persistResponseDto.hasTeam()).isTrue(),
+            () -> assertThat(persistResponseDto.preferenceCompleted()).isTrue()
+        );
+    }
+
+    @DisplayName("존재하지 않는 사용자의 persist 정보를 가져오는데 실패한다.")
+    @Test
+    void persistLoginFail() {
+        // given
+        final Long invalidMemberId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.persistLogin(invalidMemberId))
+            .isExactlyInstanceOf(AccessTokenNotFoundException.class);
+    }
+
+    static class PersistLoginRepositoryRepositoryStub implements PersistLoginRepository {
+
+        @Override
+        public PersistResponseDto findPersistResponseById(Long memberId) {
+            if (memberId == 999L) {
+                throw new AccessTokenNotFoundException();
+            }
+
+            return PersistResponseDto.builder()
+                .nickname("kai")
+                .preferenceCompleted(true)
+                .hasMainProfileImage(true)
+                .emailAuthenticated(true)
+                .hasTeam(true)
+                .profileImageAuthenticated(false)
+                .build();
+        }
+    }
+}

--- a/src/test/java/com/e2i/wemeet/support/config/AbstractControllerUnitTest.java
+++ b/src/test/java/com/e2i/wemeet/support/config/AbstractControllerUnitTest.java
@@ -18,11 +18,11 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 
 @ExtendWith(RestDocumentationExtension.class)
-public abstract class AbstractUnitTest {
+public abstract class AbstractControllerUnitTest {
 
     @Autowired
     protected ObjectMapper mapper;
-    
+
     protected MockMvc mockMvc;
 
     @BeforeEach

--- a/src/test/java/com/e2i/wemeet/support/config/QueryDslTestConfig.java
+++ b/src/test/java/com/e2i/wemeet/support/config/QueryDslTestConfig.java
@@ -1,0 +1,30 @@
+package com.e2i.wemeet.support.config;
+
+import com.e2i.wemeet.domain.member.persist.PersistLoginRepositoryImpl;
+import com.e2i.wemeet.util.encryption.AdvancedEncryptionStandard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@EnableConfigurationProperties(AdvancedEncryptionStandard.class)
+@TestConfiguration
+public class QueryDslTestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+    @Bean
+    public PersistLoginRepositoryImpl persistLoginImpl(JPAQueryFactory jpaQueryFactory) {
+        return new PersistLoginRepositoryImpl(jpaQueryFactory);
+    }
+}

--- a/src/test/java/com/e2i/wemeet/support/config/RepositoryTest.java
+++ b/src/test/java/com/e2i/wemeet/support/config/RepositoryTest.java
@@ -1,0 +1,20 @@
+package com.e2i.wemeet.support.config;
+
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@AutoConfigureTestDatabase(replace = NONE)
+@Import(QueryDslTestConfig.class)
+@DataJpaTest
+public @interface RepositoryTest {
+
+}

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -92,6 +92,18 @@ public enum MemberFixture {
             .build();
     }
 
+    public Member create_preference(final Preference preference) {
+        return createBuilder()
+            .preference(preference)
+            .build();
+    }
+
+    public Member create_college(final CollegeInfo collegeInfo) {
+        return createBuilder()
+            .collegeInfo(collegeInfo)
+            .build();
+    }
+
     private Member.MemberBuilder createBuilder() {
         return Member.builder()
             .memberId(this.memberId)

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -10,6 +10,7 @@ import com.e2i.wemeet.domain.member.Gender;
 import com.e2i.wemeet.domain.member.Mbti;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.Preference;
+import com.e2i.wemeet.domain.member.RegistrationType;
 import com.e2i.wemeet.domain.member.Role;
 import com.e2i.wemeet.dto.request.member.CreateMemberRequestDto;
 import com.e2i.wemeet.dto.request.member.ModifyMemberRequestDto;
@@ -103,6 +104,7 @@ public enum MemberFixture {
             .mbti(this.mbti)
             .introduction(this.introduction)
             .credit(this.credit)
+            .registrationType(RegistrationType.APP)
             .role(this.role);
     }
 

--- a/src/test/java/com/e2i/wemeet/support/fixture/ProfileImageFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/ProfileImageFixture.java
@@ -4,7 +4,7 @@ import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.profileimage.ProfileImage;
 
 public enum ProfileImageFixture {
-    
+
     MAIN_IMAGE("basic", "blur", "lowBasic", "lowBlur", true, true, MemberFixture.KAI.create()),
     ADDITIONAL_IMAGE("basic", "blur", "lowBasic", "lowBlur", false, false,
         MemberFixture.KAI.create());
@@ -39,14 +39,24 @@ public enum ProfileImageFixture {
     }
 
     public ProfileImage create() {
+        return createBuilder()
+            .member(member)
+            .build();
+    }
+
+    public ProfileImage create(Member member) {
+        return createBuilder()
+            .member(member)
+            .build();
+    }
+
+    private ProfileImage.ProfileImageBuilder createBuilder() {
         return ProfileImage.builder()
             .basicUrl(basicUrl)
             .blurUrl(blurUrl)
             .lowResolutionBasicUrl(lowResolutionBasicUrl)
             .lowResolutionBlurUrl(lowResolutionBlurUrl)
             .isMain(isMain)
-            .isCertified(isCertified)
-            .member(member)
-            .build();
+            .isCertified(isCertified);
     }
 }

--- a/src/test/java/com/e2i/wemeet/support/fixture/TeamFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/TeamFixture.java
@@ -12,7 +12,9 @@ import java.util.List;
 public enum TeamFixture {
 
     TEST_TEAM(1L, "df42hg", 3, Gender.MALE, "건대입구", "0", AdditionalActivity.SHOW,
-        "안녕하세요. 저희 팀은 멋쟁이 팀입니다.", MemberFixture.KAI.create());
+        "안녕하세요. 저희 팀은 멋쟁이 팀입니다.", MemberFixture.KAI.create()),
+    HONGDAE_TEAM(null, "hongda", 3, null, "홍대 입구", "0", AdditionalActivity.SHOW,
+        "안녕하세요. 홍대 팀 인사올립니다.", null);;
 
     private final Long teamId;
     private final String teamCode;
@@ -50,6 +52,23 @@ public enum TeamFixture {
             .build();
     }
 
+    public Team create(Member teamLeader) {
+        return createTeamBuilder(teamLeader)
+            .build();
+    }
+
+    public Team.TeamBuilder createTeamBuilder(Member member) {
+        return Team.builder()
+            .teamCode(member.getMemberId() + "@" + this.teamCode)
+            .memberCount(this.memberCount)
+            .region(this.region)
+            .drinkingOption(this.drinkingOption)
+            .additionalActivity(this.additionalActivity)
+            .gender(member.getGender())
+            .introduction(this.introduction)
+            .teamLeader(member);
+    }
+
     public CreateTeamRequestDto createTeamRequestDto() {
         return CreateTeamRequestDto.builder()
             .memberCount(this.memberCount)
@@ -82,7 +101,7 @@ public enum TeamFixture {
             .managerImageAuth(member.isImageAuth())
             .build();
     }
-    
+
     private Team.TeamBuilder createBuilder() {
         return Team.builder()
             .teamId(this.teamId)
@@ -92,7 +111,7 @@ public enum TeamFixture {
             .region(region)
             .drinkingOption(this.drinkingOption)
             .additionalActivity(this.additionalActivity)
-            .member(this.member)
+            .teamLeader(this.member)
             .introduction(this.introduction);
     }
 }


### PR DESCRIPTION
## Related Issue

## Description
- [x] Persist Login
- [x] RegistrationType 추가
- [x] Phone 인증 시, emai 인증 여부도 전달하도록 변경
- [x] MemberId용 ArgumentResolver 추가

## Screenshots (if appropriate):
### 1. @MemberId 추가
- MemberPrincipal에서 memberId를 가져오는 작업이 불필요하다고 생각해서 Controller 상에서 AccessToken에 저장된 MemberId를 바로 받아올 수 있도록 ArgumentResolver를 정의하였습니다.
- 다음과 같이 Long 형에 @MemberId 를 붙임으로써 사용자의 Id 값을 가져올 수 있습니다.
```java
@RestController
public class TokenController {

    private final TokenService tokenService;

    @GetMapping("/persist")
    public ResponseDto<PersistResponseDto> persist(@MemberId Long memberId) {
        PersistResponseDto result = tokenService.persistLogin(memberId);
        return new ResponseDto<>(ResponseStatus.SUCCESS, "Persist Login Success", result);
    }
}
```
### 2. @RepositoryTest 추가
- DataJpaTest 용 어노테이션을 추가했습니다. 
  - 작성된 쿼리에 대해서 테스트 할 용도로 사용합니다. 
  - @DataJpaTest는 DB Connection을 위한 최소한의 Bean만 등록하기 때문에 다른 테스트에 비해 가볍습니다.  
```java
@Target(ElementType.TYPE)
@Retention(RetentionPolicy.RUNTIME)
@AutoConfigureTestDatabase(replace = NONE)
@Import(QueryDslTestConfig.class)
@DataJpaTest
public @interface RepositoryTest {
}

@RepositoryTest
class PersistLoginRepositoryImplTest {

    @PersistenceContext
    EntityManager entityManager;

    @Autowired
    private MemberRepository memberRepository;

    ...
}
```