### PR TITLE
feat(enum): Apply JPA Attribute Converter to Enum field of entity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.1.0'
     implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.4.1'
 
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'

--- a/src/main/java/com/e2i/wemeet/domain/base/BaseTimeEntity.java
+++ b/src/main/java/com/e2i/wemeet/domain/base/BaseTimeEntity.java
@@ -15,5 +15,5 @@ public abstract class BaseTimeEntity extends CreateTimeEntity {
 
     @LastModifiedDate
     @Column(name = "MODIFIED_AT")
-    private LocalDateTime modifiedAt;
+    protected LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/e2i/wemeet/domain/base/CreateTimeEntity.java
+++ b/src/main/java/com/e2i/wemeet/domain/base/CreateTimeEntity.java
@@ -15,6 +15,6 @@ public abstract class CreateTimeEntity {
 
     @CreatedDate
     @Column(name = "CREATED_AT")
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/e2i/wemeet/domain/base/converter/AcceptStatusConverter.java
+++ b/src/main/java/com/e2i/wemeet/domain/base/converter/AcceptStatusConverter.java
@@ -1,0 +1,28 @@
+package com.e2i.wemeet.domain.base.converter;
+
+import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
+import com.e2i.wemeet.exception.badrequest.InvalidDatabaseKeyToEnumException;
+import jakarta.persistence.AttributeConverter;
+import java.util.Arrays;
+
+public class AcceptStatusConverter implements AttributeConverter<AcceptStatus, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(AcceptStatus attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getKey();
+    }
+
+    @Override
+    public AcceptStatus convertToEntityAttribute(Integer dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return Arrays.stream(AcceptStatus.values())
+            .filter(acceptStatus -> acceptStatus.getKey() == dbData)
+            .findFirst()
+            .orElseThrow(InvalidDatabaseKeyToEnumException::new);
+    }
+}

--- a/src/main/java/com/e2i/wemeet/domain/base/converter/AcceptStatusConverter.java
+++ b/src/main/java/com/e2i/wemeet/domain/base/converter/AcceptStatusConverter.java
@@ -1,9 +1,7 @@
 package com.e2i.wemeet.domain.base.converter;
 
 import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
-import com.e2i.wemeet.exception.badrequest.InvalidDatabaseKeyToEnumException;
 import jakarta.persistence.AttributeConverter;
-import java.util.Arrays;
 
 public class AcceptStatusConverter implements AttributeConverter<AcceptStatus, Integer> {
 
@@ -20,9 +18,6 @@ public class AcceptStatusConverter implements AttributeConverter<AcceptStatus, I
         if (dbData == null) {
             return null;
         }
-        return Arrays.stream(AcceptStatus.values())
-            .filter(acceptStatus -> acceptStatus.getKey() == dbData)
-            .findFirst()
-            .orElseThrow(InvalidDatabaseKeyToEnumException::new);
+        return AcceptStatus.findByKey(dbData);
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/base/converter/AdditionalActivityConverter.java
+++ b/src/main/java/com/e2i/wemeet/domain/base/converter/AdditionalActivityConverter.java
@@ -1,0 +1,23 @@
+package com.e2i.wemeet.domain.base.converter;
+
+import com.e2i.wemeet.domain.team.data.AdditionalActivity;
+import jakarta.persistence.AttributeConverter;
+
+public class AdditionalActivityConverter implements AttributeConverter<AdditionalActivity, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(AdditionalActivity attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getKey();
+    }
+
+    @Override
+    public AdditionalActivity convertToEntityAttribute(Integer dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return AdditionalActivity.findByKey(dbData);
+    }
+}

--- a/src/main/java/com/e2i/wemeet/domain/base/converter/CollegeTypeConverter.java
+++ b/src/main/java/com/e2i/wemeet/domain/base/converter/CollegeTypeConverter.java
@@ -1,0 +1,23 @@
+package com.e2i.wemeet.domain.base.converter;
+
+import com.e2i.wemeet.domain.member.data.CollegeType;
+import jakarta.persistence.AttributeConverter;
+
+public class CollegeTypeConverter implements AttributeConverter<CollegeType, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(CollegeType attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getKey();
+    }
+
+    @Override
+    public CollegeType convertToEntityAttribute(Integer dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return CollegeType.findByKey(dbData);
+    }
+}

--- a/src/main/java/com/e2i/wemeet/domain/base/converter/DrinkWithGameConverter.java
+++ b/src/main/java/com/e2i/wemeet/domain/base/converter/DrinkWithGameConverter.java
@@ -1,0 +1,23 @@
+package com.e2i.wemeet.domain.base.converter;
+
+import com.e2i.wemeet.domain.team.data.DrinkWithGame;
+import jakarta.persistence.AttributeConverter;
+
+public class DrinkWithGameConverter implements AttributeConverter<DrinkWithGame, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(DrinkWithGame attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getKey();
+    }
+
+    @Override
+    public DrinkWithGame convertToEntityAttribute(Integer dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return DrinkWithGame.findByKey(dbData);
+    }
+}

--- a/src/main/java/com/e2i/wemeet/domain/base/converter/GenderConverter.java
+++ b/src/main/java/com/e2i/wemeet/domain/base/converter/GenderConverter.java
@@ -1,0 +1,28 @@
+package com.e2i.wemeet.domain.base.converter;
+
+import com.e2i.wemeet.domain.member.data.Gender;
+import com.e2i.wemeet.exception.badrequest.InvalidDatabaseKeyToEnumException;
+import jakarta.persistence.AttributeConverter;
+
+public class GenderConverter implements AttributeConverter<Gender, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Gender attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getKey();
+    }
+
+    @Override
+    public Gender convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        } else if (dbData.equals(Gender.MAN.getKey())) {
+            return Gender.MAN;
+        } else if (dbData.equals(Gender.WOMAN.getKey())) {
+            return Gender.WOMAN;
+        }
+        throw new InvalidDatabaseKeyToEnumException();
+    }
+}

--- a/src/main/java/com/e2i/wemeet/domain/base/converter/MbtiConverter.java
+++ b/src/main/java/com/e2i/wemeet/domain/base/converter/MbtiConverter.java
@@ -1,0 +1,23 @@
+package com.e2i.wemeet.domain.base.converter;
+
+import com.e2i.wemeet.domain.member.data.Mbti;
+import jakarta.persistence.AttributeConverter;
+
+public class MbtiConverter implements AttributeConverter<Mbti, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(Mbti attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getKey();
+    }
+
+    @Override
+    public Mbti convertToEntityAttribute(Integer dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return Mbti.findByKey(dbData);
+    }
+}

--- a/src/main/java/com/e2i/wemeet/domain/base/converter/RegionConverter.java
+++ b/src/main/java/com/e2i/wemeet/domain/base/converter/RegionConverter.java
@@ -1,0 +1,23 @@
+package com.e2i.wemeet.domain.base.converter;
+
+import com.e2i.wemeet.domain.team.data.Region;
+import jakarta.persistence.AttributeConverter;
+
+public class RegionConverter implements AttributeConverter<Region, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(Region attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getKey();
+    }
+
+    @Override
+    public Region convertToEntityAttribute(Integer dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return Region.findByKey(dbData);
+    }
+}

--- a/src/main/java/com/e2i/wemeet/domain/code/Code.java
+++ b/src/main/java/com/e2i/wemeet/domain/code/Code.java
@@ -13,28 +13,39 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Persistable;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "CODE")
 @Entity
-public class Code extends BaseTimeEntity {
+public class Code extends BaseTimeEntity implements Persistable<CodePk> {
 
     @EmbeddedId
     private CodePk codePk;
 
     @Column(nullable = false)
-    private String value;
+    private String codeValue;
 
     @MapsId("groupCodeId")
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "groupCodeId")
+    @JoinColumn(name = "group_code_id")
     private GroupCode groupCode;
 
     @Builder
-    public Code(CodePk codePk, String value, GroupCode groupCode) {
-        this.codePk = codePk;
-        this.value = value;
+    public Code(String codeId, String codeValue, GroupCode groupCode) {
+        this.codePk = new CodePk(codeId, groupCode.getGroupCodeId());
+        this.codeValue = codeValue;
         this.groupCode = groupCode;
+    }
+
+    @Override
+    public CodePk getId() {
+        return this.codePk;
+    }
+
+    @Override
+    public boolean isNew() {
+        return createdAt == null;
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/code/CodePk.java
+++ b/src/main/java/com/e2i/wemeet/domain/code/CodePk.java
@@ -4,20 +4,24 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.io.Serializable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @EqualsAndHashCode
 @Embeddable
 public class CodePk implements Serializable {
 
-    @Column(length = 4, name = "codeId")
+    @Column(length = 3, name = "code_id")
     private String codeId;
 
+    @Column(length = 2, name = "group_code_id")
     private String groupCodeId;
+
+    public CodePk(String codeId, String groupCodeId) {
+        this.codeId = codeId;
+        this.groupCodeId = groupCodeId;
+    }
 }

--- a/src/main/java/com/e2i/wemeet/domain/code/GroupCode.java
+++ b/src/main/java/com/e2i/wemeet/domain/code/GroupCode.java
@@ -8,15 +8,16 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Persistable;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "GROUP_CODE")
 @Entity
-public class GroupCode extends BaseTimeEntity {
+public class GroupCode extends BaseTimeEntity implements Persistable<String> {
 
     @Id
-    @Column(length = 4)
+    @Column(length = 4, name = "group_code_id")
     private String groupCodeId;
 
     @Column(nullable = false)
@@ -25,4 +26,13 @@ public class GroupCode extends BaseTimeEntity {
     @Column(nullable = false)
     private String description;
 
+    @Override
+    public String getId() {
+        return groupCodeId;
+    }
+
+    @Override
+    public boolean isNew() {
+        return createdAt == null;
+    }
 }

--- a/src/main/java/com/e2i/wemeet/domain/meeting/MeetingRequest.java
+++ b/src/main/java/com/e2i/wemeet/domain/meeting/MeetingRequest.java
@@ -1,9 +1,11 @@
 package com.e2i.wemeet.domain.meeting;
 
 import com.e2i.wemeet.domain.base.BaseTimeEntity;
+import com.e2i.wemeet.domain.base.converter.AcceptStatusConverter;
 import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
 import com.e2i.wemeet.domain.team.Team;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -11,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,14 +34,14 @@ public class MeetingRequest extends BaseTimeEntity {
     @JoinColumn(name = "partnerTeamId", referencedColumnName = "teamId", nullable = false)
     private Team partnerTeam;
 
-    // TODO :: converter
-    // @Convert
+    @Convert(converter = AcceptStatusConverter.class)
     @Column(nullable = false)
     private AcceptStatus acceptStatus;
 
     @Column(length = 50)
     private String message;
 
+    @Builder
     public MeetingRequest(Team team, Team partnerTeam, AcceptStatus acceptStatus, String message) {
         this.team = team;
         this.partnerTeam = partnerTeam;

--- a/src/main/java/com/e2i/wemeet/domain/meeting/data/AcceptStatus.java
+++ b/src/main/java/com/e2i/wemeet/domain/meeting/data/AcceptStatus.java
@@ -1,5 +1,7 @@
 package com.e2i.wemeet.domain.meeting.data;
 
+import com.e2i.wemeet.exception.badrequest.InvalidDatabaseKeyToEnumException;
+import java.util.Arrays;
 import lombok.Getter;
 
 @Getter
@@ -13,5 +15,12 @@ public enum AcceptStatus {
 
     AcceptStatus(int key) {
         this.key = key;
+    }
+
+    public static AcceptStatus findByKey(int key) {
+        return Arrays.stream(AcceptStatus.values())
+            .filter(acceptStatus -> acceptStatus.getKey() == key)
+            .findFirst()
+            .orElseThrow(InvalidDatabaseKeyToEnumException::new);
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/member/Member.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/Member.java
@@ -2,6 +2,8 @@ package com.e2i.wemeet.domain.member;
 
 import com.e2i.wemeet.domain.base.BaseTimeEntity;
 import com.e2i.wemeet.domain.base.converter.CryptoConverter;
+import com.e2i.wemeet.domain.base.converter.GenderConverter;
+import com.e2i.wemeet.domain.base.converter.MbtiConverter;
 import com.e2i.wemeet.domain.member.data.CollegeInfo;
 import com.e2i.wemeet.domain.member.data.Gender;
 import com.e2i.wemeet.domain.member.data.Mbti;
@@ -39,8 +41,8 @@ public class Member extends BaseTimeEntity {
     @Column(length = 20, nullable = false)
     private String nickname;
 
-    @Column(length = 6, nullable = false)
-    @Enumerated(value = EnumType.STRING)
+    @Convert(converter = GenderConverter.class)
+    @Column(nullable = false)
     private Gender gender;
 
     @Convert(converter = CryptoConverter.class)
@@ -54,8 +56,7 @@ public class Member extends BaseTimeEntity {
     @Embedded
     private CollegeInfo collegeInfo;
 
-    @Column(length = 7, nullable = false)
-    @Enumerated(value = EnumType.STRING)
+    @Convert(converter = MbtiConverter.class)
     private Mbti mbti;
 
     @Column(nullable = false)

--- a/src/main/java/com/e2i/wemeet/domain/member/data/CollegeInfo.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/data/CollegeInfo.java
@@ -1,7 +1,9 @@
 package com.e2i.wemeet.domain.member.data;
 
+import com.e2i.wemeet.domain.base.converter.CollegeTypeConverter;
 import com.e2i.wemeet.domain.code.Code;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -20,14 +22,14 @@ public class CollegeInfo {
     @JoinColumn(name = "collegeGroupCodeId", referencedColumnName = "groupCodeId")
     private Code collegeCode;
 
-    @Column(length = 20, nullable = false)
-    private String collegeType;
+    @Convert(converter = CollegeTypeConverter.class)
+    private CollegeType collegeType;
 
     @Column(length = 2, nullable = false)
     private String admissionYear;
 
     @Builder
-    public CollegeInfo(Code collegeCode, String collegeType, String admissionYear) {
+    public CollegeInfo(Code collegeCode, CollegeType collegeType, String admissionYear) {
         this.collegeCode = collegeCode;
         this.collegeType = collegeType;
         this.admissionYear = admissionYear;

--- a/src/main/java/com/e2i/wemeet/domain/member/data/CollegeInfo.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/data/CollegeInfo.java
@@ -18,8 +18,8 @@ import lombok.NoArgsConstructor;
 public class CollegeInfo {
 
     @ManyToOne
-    @JoinColumn(name = "collegeCodeId", referencedColumnName = "codeId")
-    @JoinColumn(name = "collegeGroupCodeId", referencedColumnName = "groupCodeId")
+    @JoinColumn(name = "collegeCodeId", referencedColumnName = "code_id")
+    @JoinColumn(name = "collegeGroupCodeId", referencedColumnName = "group_code_id")
     private Code collegeCode;
 
     @Convert(converter = CollegeTypeConverter.class)

--- a/src/main/java/com/e2i/wemeet/domain/member/data/CollegeType.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/data/CollegeType.java
@@ -1,0 +1,31 @@
+package com.e2i.wemeet.domain.member.data;
+
+import com.e2i.wemeet.exception.badrequest.InvalidDatabaseKeyToEnumException;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum CollegeType {
+    ETC(0, "그 외"),
+    SOCIAL(1, "인문/사회"),
+    ENGINEERING(2, "자연/공학"),
+    ARTS(3, "예체능"),
+    EDUCATION(4, "교육"),
+    MEDICINE(5, "의약"),
+    ;
+
+    private final int key;
+    private final String description;
+
+    CollegeType(int key, String description) {
+        this.key = key;
+        this.description = description;
+    }
+
+    public static CollegeType findByKey(int key) {
+        return Arrays.stream(CollegeType.values())
+            .filter(collegeType -> collegeType.getKey() == key)
+            .findFirst()
+            .orElseThrow(InvalidDatabaseKeyToEnumException::new);
+    }
+}

--- a/src/main/java/com/e2i/wemeet/domain/member/data/Mbti.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/data/Mbti.java
@@ -1,6 +1,7 @@
 package com.e2i.wemeet.domain.member.data;
 
 import com.e2i.wemeet.exception.ErrorCode;
+import com.e2i.wemeet.exception.badrequest.InvalidDatabaseKeyToEnumException;
 import com.e2i.wemeet.exception.badrequest.InvalidValueException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;
@@ -26,5 +27,12 @@ public enum Mbti {
             .filter(mbti -> mbti.name().equals(value.toUpperCase()))
             .findFirst()
             .orElseThrow(() -> new InvalidValueException(ErrorCode.INVALID_MBTI_VALUE));
+    }
+
+    public static Mbti findByKey(int key) {
+        return Arrays.stream(Mbti.values())
+            .filter(mbti -> mbti.getKey() == key)
+            .findFirst()
+            .orElseThrow(InvalidDatabaseKeyToEnumException::new);
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/team/Team.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/Team.java
@@ -3,6 +3,7 @@ package com.e2i.wemeet.domain.team;
 import com.e2i.wemeet.domain.base.BaseTimeEntity;
 import com.e2i.wemeet.domain.base.converter.AdditionalActivityConverter;
 import com.e2i.wemeet.domain.base.converter.DrinkWithGameConverter;
+import com.e2i.wemeet.domain.base.converter.GenderConverter;
 import com.e2i.wemeet.domain.base.converter.RegionConverter;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.data.Gender;
@@ -15,8 +16,6 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -46,8 +45,7 @@ public class Team extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer memberNum;
 
-    @Column(length = 6, nullable = false)
-    @Enumerated(value = EnumType.STRING)
+    @Convert(converter = GenderConverter.class)
     private Gender gender;
 
     @Convert(converter = RegionConverter.class)
@@ -68,7 +66,7 @@ public class Team extends BaseTimeEntity {
     private String introduction;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "memberId")
+    @JoinColumn(name = "team_leader_id", updatable = false, nullable = false)
     private Member teamLeader;
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.PERSIST)

--- a/src/main/java/com/e2i/wemeet/domain/team/Team.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/Team.java
@@ -1,6 +1,9 @@
 package com.e2i.wemeet.domain.team;
 
 import com.e2i.wemeet.domain.base.BaseTimeEntity;
+import com.e2i.wemeet.domain.base.converter.AdditionalActivityConverter;
+import com.e2i.wemeet.domain.base.converter.DrinkWithGameConverter;
+import com.e2i.wemeet.domain.base.converter.RegionConverter;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.data.Gender;
 import com.e2i.wemeet.domain.team.data.AdditionalActivity;
@@ -10,6 +13,7 @@ import com.e2i.wemeet.domain.team_member.TeamMember;
 import com.e2i.wemeet.exception.badrequest.TeamHasBeenDeletedException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -46,21 +50,18 @@ public class Team extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private Gender gender;
 
-    // TODO : Converter 적용
-    // @Convert
+    @Convert(converter = RegionConverter.class)
     @Column(length = 20, nullable = false)
     private Region region;
 
     @Column(nullable = false)
     private Integer drinkRate;
 
-    // TODO : Converter 적용
-    // @Convert
+    @Convert(converter = DrinkWithGameConverter.class)
     @Column(nullable = false)
     private DrinkWithGame drinkWithGame;
 
-    // TODO : Converter 적용
-    // @Convert
+    @Convert(converter = AdditionalActivityConverter.class)
     private AdditionalActivity additionalActivity;
 
     @Column(length = 150, nullable = false)
@@ -95,5 +96,13 @@ public class Team extends BaseTimeEntity {
             throw new TeamHasBeenDeletedException();
         }
         return this;
+    }
+
+    public void addTeamMembers(List<TeamMember> teamMembers) {
+        teamMembers.forEach(this::addTeamMember);
+    }
+
+    public void addTeamMember(TeamMember teamMember) {
+        teamMember.setTeam(this);
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/team/data/AdditionalActivity.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/data/AdditionalActivity.java
@@ -1,6 +1,7 @@
 package com.e2i.wemeet.domain.team.data;
 
 import com.e2i.wemeet.exception.ErrorCode;
+import com.e2i.wemeet.exception.badrequest.InvalidDatabaseKeyToEnumException;
 import com.e2i.wemeet.exception.badrequest.InvalidValueException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;
@@ -34,5 +35,12 @@ public enum AdditionalActivity {
             .findFirst()
             .orElseThrow(
                 () -> new InvalidValueException(ErrorCode.INVALID_ADDITIONAL_ACTIVITY_VALUE));
+    }
+
+    public static AdditionalActivity findByKey(int key) {
+        return Arrays.stream(AdditionalActivity.values())
+            .filter(additionalActivity -> additionalActivity.getKey() == key)
+            .findFirst()
+            .orElseThrow(InvalidDatabaseKeyToEnumException::new);
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/team/data/DrinkWithGame.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/data/DrinkWithGame.java
@@ -1,5 +1,8 @@
 package com.e2i.wemeet.domain.team.data;
 
+import com.e2i.wemeet.exception.badrequest.InvalidDatabaseKeyToEnumException;
+import java.util.Arrays;
+
 public enum DrinkWithGame {
     ANY(0, "상관 없어"),
     MASTER(1, "나는야 술게임 고수"),
@@ -12,5 +15,16 @@ public enum DrinkWithGame {
     DrinkWithGame(int key, String name) {
         this.key = key;
         this.name = name;
+    }
+
+    public static DrinkWithGame findByKey(int key) {
+        return Arrays.stream(DrinkWithGame.values())
+            .filter(drinkWithGame -> drinkWithGame.getKey() == key)
+            .findFirst()
+            .orElseThrow(InvalidDatabaseKeyToEnumException::new);
+    }
+
+    public int getKey() {
+        return key;
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/team/data/Region.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/data/Region.java
@@ -1,5 +1,7 @@
 package com.e2i.wemeet.domain.team.data;
 
+import com.e2i.wemeet.exception.badrequest.InvalidDatabaseKeyToEnumException;
+import java.util.Arrays;
 import lombok.Getter;
 
 @Getter
@@ -15,5 +17,12 @@ public enum Region {
     Region(int key, String name) {
         this.key = key;
         this.name = name;
+    }
+
+    public static Region findByKey(int key) {
+        return Arrays.stream(Region.values())
+            .filter(region -> region.getKey() == key)
+            .findFirst()
+            .orElseThrow(InvalidDatabaseKeyToEnumException::new);
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/team_member/TeamMember.java
+++ b/src/main/java/com/e2i/wemeet/domain/team_member/TeamMember.java
@@ -1,9 +1,11 @@
 package com.e2i.wemeet.domain.team_member;
 
 import com.e2i.wemeet.domain.base.BaseTimeEntity;
+import com.e2i.wemeet.domain.base.converter.MbtiConverter;
 import com.e2i.wemeet.domain.member.data.CollegeInfo;
 import com.e2i.wemeet.domain.member.data.Mbti;
 import com.e2i.wemeet.domain.team.Team;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -29,8 +31,7 @@ public class TeamMember extends BaseTimeEntity {
     @Embedded
     private CollegeInfo collegeInfo;
 
-    // TODO :: converter
-    // @Convert
+    @Convert(converter = MbtiConverter.class)
     private Mbti mbti;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -42,6 +43,13 @@ public class TeamMember extends BaseTimeEntity {
         this.collegeInfo = collegeInfo;
         this.mbti = mbti;
         this.team = team;
+    }
+
+    public void setTeam(Team team) {
+        this.team = team;
+        if (!team.getTeamMembers().contains(this)) {
+            team.getTeamMembers().add(this);
+        }
     }
 }
 

--- a/src/main/java/com/e2i/wemeet/dto/request/member/CreateMemberRequestDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/request/member/CreateMemberRequestDto.java
@@ -42,7 +42,6 @@ public record CreateMemberRequestDto(
             .gender(Gender.findBy(gender))
             .phoneNumber(phoneNumber)
             .collegeInfo(CollegeInfo.builder()
-                .collegeType(collegeInfo.collegeType())
                 .admissionYear(collegeInfo().admissionYear())
                 .build())
             .mbti(Mbti.findBy(mbti))

--- a/src/main/java/com/e2i/wemeet/exception/ErrorCode.java
+++ b/src/main/java/com/e2i/wemeet/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     MEMBER_HAS_BEEN_DELETED(40022, "member.has.been.deleted"),
     TEAM_HAS_BEEN_DELETED(40023, "team.has.been.deleted"),
     INVALID_HTTP_REQUEST(40024, "invalid.http.request"),
+    INVALID_DATABASE_KEY_TO_ENUM(40025, "invalid.database.key.to.enum"),
 
 
     NOTFOUND_SMS_CREDENTIAL(40100, "notfound.sms.credential"),

--- a/src/main/java/com/e2i/wemeet/exception/badrequest/InvalidDatabaseKeyToEnumException.java
+++ b/src/main/java/com/e2i/wemeet/exception/badrequest/InvalidDatabaseKeyToEnumException.java
@@ -1,0 +1,14 @@
+package com.e2i.wemeet.exception.badrequest;
+
+import com.e2i.wemeet.exception.ErrorCode;
+
+public class InvalidDatabaseKeyToEnumException extends InvalidValueException {
+
+    public InvalidDatabaseKeyToEnumException() {
+        super(ErrorCode.INVALID_DATABASE_KEY_TO_ENUM);
+    }
+
+    public InvalidDatabaseKeyToEnumException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/resources/db/migration/V2306211556__create_code.sql
+++ b/src/main/resources/db/migration/V2306211556__create_code.sql
@@ -1,20 +1,24 @@
-CREATE TABLE IF NOT EXISTS `group_code` (
-    `group_code_id` char(2) NOT NULL,
-    `name` varchar(30) NOT NULL,
-    `description` varchar(100) NOT NULL,
-    `created_at` datetime(6),
-    `modified_at` datetime(6),
-    PRIMARY KEY (`group_code_id`))
+CREATE TABLE IF NOT EXISTS `group_code`
+(
+    `group_code_id` char(2)      NOT NULL,
+    `name`          varchar(30)  NOT NULL,
+    `description`   varchar(100) NOT NULL,
+    `created_at`    datetime(6),
+    `modified_at`   datetime(6),
+    PRIMARY KEY (`group_code_id`)
+)
     ENGINE = InnoDB
-    DEFAULT CHARACTER SET=utf8mb4;
+    DEFAULT CHARACTER SET = utf8mb4;
 
-CREATE TABLE IF NOT EXISTS `code` (
-    `code_id` char(3) NOT NULL,
-    `group_code_id` char(2) NOT NULL,
-    `value` varchar(255) NOT NULL,
-    `created_at` datetime(6),
-    `modified_at` datetime(6),
+CREATE TABLE IF NOT EXISTS `code`
+(
+    `code_id`       char(3)      NOT NULL,
+    `group_code_id` char(2)      NOT NULL,
+    `code_value`    varchar(255) NOT NULL,
+    `created_at`    datetime(6),
+    `modified_at`   datetime(6),
     PRIMARY KEY (`code_id`, `group_code_id`),
-    FOREIGN KEY (`group_code_id`) REFERENCES group_code (`group_code_id`) ON DELETE CASCADE)
+    FOREIGN KEY (`group_code_id`) REFERENCES group_code (`group_code_id`) ON DELETE CASCADE
+)
     ENGINE = InnoDB
-    DEFAULT CHARACTER SET=utf8mb4;
+    DEFAULT CHARACTER SET = utf8mb4;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -78,3 +78,4 @@ member.has.been.deleted=탈퇴한 회원입니다.
 team.has.been.deleted=삭제된 팀입니다.
 invalid.http.request=존재하지 않는 API 입니다.
 data.access=JDBC 데이터 접근 중 문제가 발생하였습니다.
+invalid.database.key.to.enum=데이터베이스에 저장된 Enum Key값이 유효하지 않습니다.

--- a/src/test/java/com/e2i/wemeet/config/security/manager/CreditAuthorizationManagerTest.java
+++ b/src/test/java/com/e2i/wemeet/config/security/manager/CreditAuthorizationManagerTest.java
@@ -139,11 +139,8 @@ class CreditAuthorizationManagerTest {
     static class MemberRepositoryImpl implements MemberRepository {
 
         @Override
-        public Optional<Member> findByNicknameAndMemberCode(String nickname, String memberCode) {
-            return Optional.of(
-                Member.builder()
-                    .build()
-            );
+        public Optional<Member> findByEmail(String email) {
+            return Optional.empty();
         }
 
         @Override
@@ -162,11 +159,6 @@ class CreditAuthorizationManagerTest {
 
         @Override
         public Optional<Member> findByPhoneNumber(String phoneNumber) {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<Member> findByCollegeInfoMail(String mail) {
             return Optional.empty();
         }
 

--- a/src/test/java/com/e2i/wemeet/domain/base/converter/JpaAttributeConverterTest.java
+++ b/src/test/java/com/e2i/wemeet/domain/base/converter/JpaAttributeConverterTest.java
@@ -35,10 +35,11 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
     @Autowired
     private TeamRepository teamRepository;
 
+    @DisplayName("MEETING_REQUEST 테이블의 accept_status 필드 값 변환기를 검증한다.")
     @Nested
     class AcceptStatusConverterTest {
 
-        @DisplayName("데이터 베이스에 요청을 전송할 때, accept_status field에 key 값이 바인딩된다.")
+        @DisplayName("데이터베이스에 요청을 전송할 때, '수락 상태'에 숫자 코드 값이 삽입된다.")
         @Test
         void convertToDatabaseColumn() {
             // given
@@ -68,10 +69,11 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
         }
     }
 
+    @DisplayName("TEAM 테이블의 additional_activity 필드 값 변환기를 검증한다.")
     @Nested
     class AdditionalActivityConverterTest {
 
-        @DisplayName("데이터 베이스에 요청을 전송할 때, additional_activity field에 key 값이 바인딩된다.")
+        @DisplayName("데이터베이스에 요청을 전송할 때, '추가 활동'에 숫자 코드 값이 삽입된다.")
         @Test
         void convertToDatabaseColumn() {
             // given
@@ -91,7 +93,7 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
             assertThat(acceptStatus).isEqualTo(5);
         }
 
-        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 AdditionalActivity Enum이 바인딩된다")
+        @DisplayName("데이터 베이스에서 가져온 숫자 코드 값을 객체로 변환한다")
         @Test
         void convertToEntityAttribute() {
             // given
@@ -112,10 +114,11 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
         }
     }
 
+    @DisplayName("college_type 필드 값 변환기를 검증한다.")
     @Nested
     class CollegeTypeConverterTest {
 
-        @DisplayName("데이터 베이스에 요청을 전송할 때, college_type field에 key 값이 바인딩된다.")
+        @DisplayName("데이터베이스에 요청을 전송할 때, '학과'에 숫자 코드 값이 삽입된다.")
         @Test
         void convertToDatabaseColumn() {
             // given
@@ -131,7 +134,7 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
             assertThat(collegeType).isEqualTo(2);
         }
 
-        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 CollegeType Enum이 바인딩된다")
+        @DisplayName("데이터 베이스에서 가져온 숫자 코드 값을 객체로 변환한다")
         @Test
         void convertToEntityAttribute() {
             // given
@@ -148,10 +151,11 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
         }
     }
 
+    @DisplayName("TEAM 테이블의 drink_with_game 필드 값 변환기를 검증한다.")
     @Nested
     class DrinkWithGameConverterTest {
 
-        @DisplayName("데이터 베이스에 요청을 전송할 때, drink_with_game field에 key 값이 바인딩된다.")
+        @DisplayName("데이터베이스에 요청을 전송할 때, '음주 선호 정보'에 숫자 코드 값이 삽입된다.")
         @Test
         void convertToDatabaseColumn() {
             // given
@@ -171,7 +175,7 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
             assertThat(drinkWithGame).isEqualTo(0);
         }
 
-        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 DrinkWithGame Enum이 바인딩된다")
+        @DisplayName("데이터 베이스에서 가져온 숫자 코드 값을 객체로 변환한다")
         @Test
         void convertToEntityAttribute() {
             // given
@@ -192,10 +196,11 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
         }
     }
 
+    @DisplayName("TEAM 테이블의 region 필드 값 변환기를 검증한다.")
     @Nested
     class RegionConverterTest {
 
-        @DisplayName("데이터 베이스에 요청을 전송할 때, region field에 key 값이 바인딩된다.")
+        @DisplayName("데이터베이스에 요청을 전송할 때, '미팅 지역'에 숫자 코드 값이 삽입된다.")
         @Test
         void convertToDatabaseColumn() {
             // given
@@ -215,7 +220,7 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
             assertThat(region).isEqualTo(1);
         }
 
-        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 Region Enum이 바인딩된다")
+        @DisplayName("데이터 베이스에서 가져온 숫자 코드 값을 객체로 변환한다")
         @Test
         void convertToEntityAttribute() {
             // given
@@ -236,10 +241,11 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
         }
     }
 
+    @DisplayName("MEMBER 테이블의 gender 필드 값 변환기를 검증한다.")
     @Nested
     class GenderConverterTest {
 
-        @DisplayName("데이터 베이스에 요청을 전송할 때, gender field 에 바인딩 되는 값은 Gender의 key 값으로 변환되어 전송된다.")
+        @DisplayName("데이터베이스에 요청을 전송할 때, '성별'에 한자리 문자 코드 값이 삽입된다.")
         @Test
         void convertToDatabaseColumn() {
             // given
@@ -255,7 +261,7 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
             assertThat(genderColumn).isEqualTo("m");
         }
 
-        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 Gender Enum이 바인딩된다")
+        @DisplayName("데이터 베이스에서 가져온 문자 코드 값을 객체로 변환한다")
         @Test
         void convertToEntityAttribute() {
             // given
@@ -272,10 +278,11 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
         }
     }
 
+    @DisplayName("MEMBER 테이블의 mbti 필드 값 변환기를 검증한다.")
     @Nested
     class MbtiConverterTest {
 
-        @DisplayName("데이터 베이스에 요청을 전송할 때, mbti field 에 바인딩 되는 값은 mbti의 key 값으로 변환되어 전송된다.")
+        @DisplayName("데이터베이스에 요청을 전송할 때, 'MBTI'에 숫자 코드 값이 삽입된다.")
         @Test
         void convertToDatabaseColumn() {
             // given
@@ -291,7 +298,7 @@ public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
             assertThat(mbti).isEqualTo(15);
         }
 
-        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 Mbti Enum이 바인딩된다")
+        @DisplayName("데이터 베이스에서 가져온 숫자 코드 값을 객체로 변환한다")
         @Test
         void convertToEntityAttribute() {
             // given

--- a/src/test/java/com/e2i/wemeet/domain/base/converter/JpaAttributeConverterTest.java
+++ b/src/test/java/com/e2i/wemeet/domain/base/converter/JpaAttributeConverterTest.java
@@ -1,0 +1,310 @@
+package com.e2i.wemeet.domain.base.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.e2i.wemeet.domain.meeting.MeetingRequest;
+import com.e2i.wemeet.domain.meeting.MeetingRequestRepository;
+import com.e2i.wemeet.domain.member.Member;
+import com.e2i.wemeet.domain.member.MemberRepository;
+import com.e2i.wemeet.domain.member.data.CollegeType;
+import com.e2i.wemeet.domain.member.data.Gender;
+import com.e2i.wemeet.domain.member.data.Mbti;
+import com.e2i.wemeet.domain.team.Team;
+import com.e2i.wemeet.domain.team.TeamRepository;
+import com.e2i.wemeet.domain.team.data.AdditionalActivity;
+import com.e2i.wemeet.domain.team.data.DrinkWithGame;
+import com.e2i.wemeet.domain.team.data.Region;
+import com.e2i.wemeet.support.config.AbstractRepositoryUnitTest;
+import com.e2i.wemeet.support.fixture.MeetingRequestFixture;
+import com.e2i.wemeet.support.fixture.MemberFixture;
+import com.e2i.wemeet.support.fixture.TeamFixture;
+import com.e2i.wemeet.support.fixture.TeamMemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MeetingRequestRepository meetingRequestRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Nested
+    class AcceptStatusConverterTest {
+
+        @DisplayName("데이터 베이스에 요청을 전송할 때, accept_status field에 key 값이 바인딩된다.")
+        @Test
+        void convertToDatabaseColumn() {
+            // given
+            Member rim = memberRepository.save(MemberFixture.RIM.create(WOMANS_CODE));
+            Member kai = memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            Team womanTeam = teamRepository.save(
+                TeamFixture.HONGDAE_TEAM_1.create(rim, TeamMemberFixture.create_3_woman())
+            );
+            Team manTeam = teamRepository.save(
+                TeamFixture.HONGDAE_TEAM_1.create(kai, TeamMemberFixture.create_3_man())
+            );
+
+            MeetingRequest meetingRequest = meetingRequestRepository.save(
+                MeetingRequestFixture.BASIC_REQUEST.create(womanTeam, manTeam)
+            );
+            entityManager.flush();
+
+            // when
+            final String sql = "SELECT accept_status FROM meeting_request WHERE meeting_request_id = :meetingRequestId";
+            Integer acceptStatus = (Integer) entityManager.createNativeQuery(sql, Integer.class)
+                .setParameter("meetingRequestId", meetingRequest.getMeetingRequestId())
+                .getSingleResult();
+
+            // then
+            assertThat(acceptStatus).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    class AdditionalActivityConverterTest {
+
+        @DisplayName("데이터 베이스에 요청을 전송할 때, additional_activity field에 key 값이 바인딩된다.")
+        @Test
+        void convertToDatabaseColumn() {
+            // given
+            Member kai = memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            Team manTeam = teamRepository.save(
+                TeamFixture.HONGDAE_TEAM_1.create_with_activity(kai, TeamMemberFixture.create_3_man(), AdditionalActivity.CAFE)
+            );
+
+            // when
+            final String sql = "SELECT additional_activity FROM team WHERE team_id = :teamId";
+            Integer acceptStatus = (Integer) entityManager.createNativeQuery(sql, Integer.class)
+                .setParameter("teamId", manTeam.getTeamId())
+                .getSingleResult();
+
+            // then
+            assertThat(acceptStatus).isEqualTo(5);
+        }
+
+        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 AdditionalActivity Enum이 바인딩된다")
+        @Test
+        void convertToEntityAttribute() {
+            // given
+            Member kai = memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            teamRepository.save(
+                TeamFixture.HONGDAE_TEAM_1.create_with_activity(kai, TeamMemberFixture.create_3_man(), AdditionalActivity.CAFE)
+            );
+
+            // when
+            final String sql = "SELECT t.additionalActivity FROM Team t WHERE t.additionalActivity = :additionalActivity";
+            AdditionalActivity findAdditionalActivity = entityManager.createQuery(sql, AdditionalActivity.class)
+                .setParameter("additionalActivity", AdditionalActivity.CAFE)
+                .getSingleResult();
+
+            // then
+            assertThat(findAdditionalActivity).isEqualTo(AdditionalActivity.CAFE);
+        }
+    }
+
+    @Nested
+    class CollegeTypeConverterTest {
+
+        @DisplayName("데이터 베이스에 요청을 전송할 때, college_type field에 key 값이 바인딩된다.")
+        @Test
+        void convertToDatabaseColumn() {
+            // given
+            Member kai = memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            // when
+            final String sql = "SELECT college_type FROM member WHERE member_id = :memberId";
+            Integer collegeType = (Integer) entityManager.createNativeQuery(sql, Integer.class)
+                .setParameter("memberId", kai.getMemberId())
+                .getSingleResult();
+
+            // then
+            assertThat(collegeType).isEqualTo(2);
+        }
+
+        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 CollegeType Enum이 바인딩된다")
+        @Test
+        void convertToEntityAttribute() {
+            // given
+            memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            // when
+            final String sql = "SELECT m.collegeInfo.collegeType FROM Member m WHERE m.collegeInfo.collegeType = :collegeType";
+            CollegeType findCollegeType = entityManager.createQuery(sql, CollegeType.class)
+                .setParameter("collegeType", CollegeType.ENGINEERING)
+                .getSingleResult();
+
+            // then
+            assertThat(findCollegeType).isEqualTo(CollegeType.ENGINEERING);
+        }
+    }
+
+    @Nested
+    class DrinkWithGameConverterTest {
+
+        @DisplayName("데이터 베이스에 요청을 전송할 때, drink_with_game field에 key 값이 바인딩된다.")
+        @Test
+        void convertToDatabaseColumn() {
+            // given
+            Member kai = memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            Team manTeam = teamRepository.save(
+                TeamFixture.HONGDAE_TEAM_1.create_with_activity(kai, TeamMemberFixture.create_3_man(), AdditionalActivity.CAFE)
+            );
+
+            // when
+            final String sql = "SELECT drink_with_game FROM team WHERE team_id = :teamId";
+            Integer drinkWithGame = (Integer) entityManager.createNativeQuery(sql, Integer.class)
+                .setParameter("teamId", manTeam.getTeamId())
+                .getSingleResult();
+
+            // then
+            assertThat(drinkWithGame).isEqualTo(0);
+        }
+
+        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 DrinkWithGame Enum이 바인딩된다")
+        @Test
+        void convertToEntityAttribute() {
+            // given
+            Member kai = memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            teamRepository.save(
+                TeamFixture.HONGDAE_TEAM_1.create_with_activity(kai, TeamMemberFixture.create_3_man(), AdditionalActivity.CAFE)
+            );
+
+            // when
+            final String sql = "SELECT t.drinkWithGame FROM Team t WHERE t.drinkWithGame = :drinkWithGame";
+            DrinkWithGame findDrinkWithGame = entityManager.createQuery(sql, DrinkWithGame.class)
+                .setParameter("drinkWithGame", DrinkWithGame.ANY)
+                .getSingleResult();
+
+            // then
+            assertThat(findDrinkWithGame).isEqualTo(DrinkWithGame.ANY);
+        }
+    }
+
+    @Nested
+    class RegionConverterTest {
+
+        @DisplayName("데이터 베이스에 요청을 전송할 때, region field에 key 값이 바인딩된다.")
+        @Test
+        void convertToDatabaseColumn() {
+            // given
+            Member kai = memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            Team manTeam = teamRepository.save(
+                TeamFixture.HONGDAE_TEAM_1.create(kai, TeamMemberFixture.create_3_man())
+            );
+
+            // when
+            final String sql = "SELECT region FROM team WHERE team_id = :teamId";
+            Integer region = (Integer) entityManager.createNativeQuery(sql, Integer.class)
+                .setParameter("teamId", manTeam.getTeamId())
+                .getSingleResult();
+
+            // then
+            assertThat(region).isEqualTo(1);
+        }
+
+        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 Region Enum이 바인딩된다")
+        @Test
+        void convertToEntityAttribute() {
+            // given
+            Member kai = memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            teamRepository.save(
+                TeamFixture.HONGDAE_TEAM_1.create(kai, TeamMemberFixture.create_3_man())
+            );
+
+            // when
+            final String sql = "SELECT t.region FROM Team t WHERE t.region = :region";
+            Region findRegion = entityManager.createQuery(sql, Region.class)
+                .setParameter("region", Region.HONGDAE)
+                .getSingleResult();
+
+            // then
+            assertThat(findRegion).isEqualTo(Region.HONGDAE);
+        }
+    }
+
+    @Nested
+    class GenderConverterTest {
+
+        @DisplayName("데이터 베이스에 요청을 전송할 때, gender field 에 바인딩 되는 값은 Gender의 key 값으로 변환되어 전송된다.")
+        @Test
+        void convertToDatabaseColumn() {
+            // given
+            Member member = memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            // when
+            final String sql = "SELECT gender FROM member WHERE member_id = :memberId";
+            String genderColumn = String.valueOf(entityManager.createNativeQuery(sql)
+                .setParameter("memberId", member.getMemberId())
+                .getSingleResult());
+
+            // then
+            assertThat(genderColumn).isEqualTo("m");
+        }
+
+        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 Gender Enum이 바인딩된다")
+        @Test
+        void convertToEntityAttribute() {
+            // given
+            memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            // when
+            final String sql = "SELECT m FROM Member m WHERE gender = :gender";
+            Member findMember = entityManager.createQuery(sql, Member.class)
+                .setParameter("gender", Gender.MAN)
+                .getSingleResult();
+
+            // then
+            assertThat(findMember.getGender()).isEqualTo(Gender.MAN);
+        }
+    }
+
+    @Nested
+    class MbtiConverterTest {
+
+        @DisplayName("데이터 베이스에 요청을 전송할 때, mbti field 에 바인딩 되는 값은 mbti의 key 값으로 변환되어 전송된다.")
+        @Test
+        void convertToDatabaseColumn() {
+            // given
+            Member member = memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            // when
+            final String sql = "SELECT mbti FROM member WHERE member_id = :memberId";
+            Integer mbti = (Integer) entityManager.createNativeQuery(sql, Integer.class)
+                .setParameter("memberId", member.getMemberId())
+                .getSingleResult();
+
+            // then
+            assertThat(mbti).isEqualTo(15);
+        }
+
+        @DisplayName("데이터 베이스에서 가져온 값이 바인딩 될 때 Entity에 Mbti Enum이 바인딩된다")
+        @Test
+        void convertToEntityAttribute() {
+            // given
+            memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));
+
+            // when
+            final String sql = "SELECT m.mbti FROM Member m WHERE mbti = :mbti";
+            Mbti findMbti = entityManager.createQuery(sql, Mbti.class)
+                .setParameter("mbti", Mbti.INFJ)
+                .getSingleResult();
+
+            // then
+            assertThat(findMbti).isEqualTo(Mbti.INFJ);
+        }
+    }
+}

--- a/src/test/java/com/e2i/wemeet/service/code/CodeServiceTest.java
+++ b/src/test/java/com/e2i/wemeet/service/code/CodeServiceTest.java
@@ -37,8 +37,8 @@ class CodeServiceTest {
         String description = "코드 설명";
 
         Code testCode = Code.builder()
-            .codePk(new CodePk(codeId, groupCodeId))
-            .value(codeName)
+            .codeId(codeId)
+            .codeValue(codeName)
             .build();
 
         List<String> dataList = List.of("G001_C001");

--- a/src/test/java/com/e2i/wemeet/service/team/TeamServiceTest.java
+++ b/src/test/java/com/e2i/wemeet/service/team/TeamServiceTest.java
@@ -22,6 +22,7 @@ import com.e2i.wemeet.exception.unauthorized.UnAuthorizedUnivException;
 import com.e2i.wemeet.security.token.TokenInjector;
 import com.e2i.wemeet.support.fixture.MemberFixture;
 import com.e2i.wemeet.support.fixture.TeamFixture;
+import com.e2i.wemeet.support.fixture.TeamMemberFixture;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,7 +64,7 @@ class TeamServiceTest {
         member = MemberFixture.KAI.create();
         manager = MemberFixture.SEYUN.create();
         inviteMember = MemberFixture.JEONGYEOL.create();
-        team = TeamFixture.TEST_TEAM.create_with_id(MemberFixture.KAI.create(), 1L);
+        team = TeamFixture.HONGDAE_TEAM_1.create(manager, TeamMemberFixture.create_3_man());
         preferenceMeetingTypeCode = new ArrayList<>();
         managerId = manager.getMemberId();
         memberId = member.getMemberId();
@@ -80,7 +81,7 @@ class TeamServiceTest {
     @Test
     void createTeam_NotFoundMember() {
         // given
-        CreateTeamRequestDto requestDto = TeamFixture.TEST_TEAM.createTeamRequestDto();
+        CreateTeamRequestDto requestDto = TeamFixture.HONGDAE_TEAM_1.createTeamRequestDto();
         when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
 
         // when & then
@@ -96,7 +97,7 @@ class TeamServiceTest {
     @Test
     void createTeam_TeamAlreadyExists() {
         // given
-        CreateTeamRequestDto requestDto = TeamFixture.TEST_TEAM.createTeamRequestDto();
+        CreateTeamRequestDto requestDto = TeamFixture.HONGDAE_TEAM_1.createTeamRequestDto();
         when(memberRepository.findById(anyLong())).thenReturn(Optional.ofNullable(member));
         // when & then
         assertThatThrownBy(
@@ -113,7 +114,7 @@ class TeamServiceTest {
     @Test
     void createTeam_UnAuthorizedUniv() {
         // given
-        CreateTeamRequestDto requestDto = TeamFixture.TEST_TEAM.createTeamRequestDto();
+        CreateTeamRequestDto requestDto = TeamFixture.HONGDAE_TEAM_1.createTeamRequestDto();
         when(memberRepository.findById(anyLong())).thenReturn(Optional.ofNullable(member));
 
         member.saveEmail(null);

--- a/src/test/java/com/e2i/wemeet/support/config/AbstractRepositoryUnitTest.java
+++ b/src/test/java/com/e2i/wemeet/support/config/AbstractRepositoryUnitTest.java
@@ -1,0 +1,50 @@
+package com.e2i.wemeet.support.config;
+
+import com.e2i.wemeet.domain.code.Code;
+import com.e2i.wemeet.domain.code.CodeRepository;
+import com.e2i.wemeet.domain.code.GroupCode;
+import com.e2i.wemeet.domain.code.GroupCodeRepository;
+import com.e2i.wemeet.support.fixture.code.CodeFixture;
+import com.e2i.wemeet.support.fixture.code.GroupCodeFixture;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RepositoryTest
+public abstract class AbstractRepositoryUnitTest {
+
+    @Autowired
+    protected EntityManager entityManager;
+
+    @Autowired
+    protected GroupCodeRepository groupCodeRepository;
+
+    @Autowired
+    protected CodeRepository codeRepository;
+
+    protected Code KOREA_CODE;
+    protected Code ANYANG_CODE;
+    protected Code INHA_CODE;
+    protected Code WOMANS_CODE;
+    protected Code HANYANG_CODE;
+
+    @BeforeEach
+    void setUpCode() {
+        GroupCode collegeGroup = groupCodeRepository.save(GroupCodeFixture.COLLEGE_CODE.create());
+
+        KOREA_CODE = codeRepository.save(CodeFixture.KOREA_UNIVERSITY.create(collegeGroup));
+        ANYANG_CODE = codeRepository.save(CodeFixture.ANYANG_UNIVERSITY.create(collegeGroup));
+        INHA_CODE = codeRepository.save(CodeFixture.INHA_UNIVERSITY.create(collegeGroup));
+        WOMANS_CODE = codeRepository.save(CodeFixture.WOMANS_UNIVERSITY.create(collegeGroup));
+        HANYANG_CODE = codeRepository.save(CodeFixture.HANYANG_UNIVERSITY.create(collegeGroup));
+    }
+
+    @AfterEach
+    void cleanUp() {
+        groupCodeRepository.deleteAll();
+        codeRepository.deleteAll();
+    }
+}

--- a/src/test/java/com/e2i/wemeet/support/config/ReflectionUtils.java
+++ b/src/test/java/com/e2i/wemeet/support/config/ReflectionUtils.java
@@ -1,0 +1,30 @@
+package com.e2i.wemeet.support.config;
+
+import com.e2i.wemeet.exception.ErrorCode;
+import com.e2i.wemeet.exception.internal.InternalServerException;
+import java.lang.reflect.Field;
+
+public abstract class ReflectionUtils {
+
+    private ReflectionUtils() {
+        throw new InternalServerException(ErrorCode.UNEXPECTED_INTERNAL);
+    }
+
+    public static <T> T createInstance(Class<T> clazz) {
+        try {
+            return clazz.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new InternalServerException(ErrorCode.UNEXPECTED_INTERNAL);
+        }
+    }
+
+    public static <T, V> void setFieldValue(T target, String fieldName, V value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            throw new InternalServerException(ErrorCode.UNEXPECTED_INTERNAL);
+        }
+    }
+}

--- a/src/test/java/com/e2i/wemeet/support/config/ReflectionUtils.java
+++ b/src/test/java/com/e2i/wemeet/support/config/ReflectionUtils.java
@@ -2,6 +2,7 @@ package com.e2i.wemeet.support.config;
 
 import com.e2i.wemeet.exception.ErrorCode;
 import com.e2i.wemeet.exception.internal.InternalServerException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 
 public abstract class ReflectionUtils {
@@ -12,7 +13,9 @@ public abstract class ReflectionUtils {
 
     public static <T> T createInstance(Class<T> clazz) {
         try {
-            return clazz.getDeclaredConstructor().newInstance();
+            Constructor<T> constructor = clazz.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
         } catch (Exception e) {
             throw new InternalServerException(ErrorCode.UNEXPECTED_INTERNAL);
         }

--- a/src/test/java/com/e2i/wemeet/support/fixture/CollegeInfoFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/CollegeInfoFixture.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 
 @Getter
 public enum CollegeInfoFixture {
+    BASIC(null, CollegeType.ENGINEERING, "20"),
     KOREA(CodeFixture.KOREA_UNIVERSITY.create(), CollegeType.ENGINEERING, "18"),
     ANYANG(CodeFixture.ANYANG_UNIVERSITY.create(), CollegeType.SOCIAL, "17"),
     WOMAN(CodeFixture.WOMANS_UNIVERSITY.create(), CollegeType.ARTS, "23"),
@@ -25,10 +26,20 @@ public enum CollegeInfoFixture {
     }
 
     public CollegeInfo create() {
+        return createBuilder()
+            .build();
+    }
+
+    public CollegeInfo create(Code collegeCode) {
+        return createBuilder()
+            .collegeCode(collegeCode)
+            .build();
+    }
+
+    private CollegeInfo.CollegeInfoBuilder createBuilder() {
         return CollegeInfo.builder()
             .collegeCode(this.collegeCode)
             .collegeType(this.collegeType)
-            .admissionYear(this.admissionYear)
-            .build();
+            .admissionYear(this.admissionYear);
     }
 }

--- a/src/test/java/com/e2i/wemeet/support/fixture/CollegeInfoFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/CollegeInfoFixture.java
@@ -1,51 +1,34 @@
 package com.e2i.wemeet.support.fixture;
 
+import com.e2i.wemeet.domain.code.Code;
 import com.e2i.wemeet.domain.member.data.CollegeInfo;
-import com.e2i.wemeet.dto.request.member.CollegeInfoRequestDto;
+import com.e2i.wemeet.domain.member.data.CollegeType;
+import com.e2i.wemeet.support.fixture.code.CodeFixture;
+import lombok.Getter;
 
-// TODO :: service refactoring
+@Getter
 public enum CollegeInfoFixture {
-    ANYANG_COLLEGE("22", "공대", "안양대학교", "pppp1234@anyang.ac.kr"),
-    KOREA_COLLEGE("18", "공대", "고려대학교", "afgds234@korea.ac.kr"),
-    SEOULWOMEN_COLLEGE("19", "공대", "서울여자대학교", "fgafd1234@swu.ac.kr");
+    KOREA(CodeFixture.KOREA_UNIVERSITY.create(), CollegeType.ENGINEERING, "18"),
+    ANYANG(CodeFixture.ANYANG_UNIVERSITY.create(), CollegeType.SOCIAL, "17"),
+    WOMAN(CodeFixture.WOMANS_UNIVERSITY.create(), CollegeType.ARTS, "23"),
+    INHA(CodeFixture.INHA_UNIVERSITY.create(), CollegeType.ENGINEERING, "22"),
+    ;
 
+    private final Code collegeCode;
+    private final CollegeType collegeType;
     private final String admissionYear;
-    private final String collegeType;
-    private final String college;
-    private final String mail;
 
-    CollegeInfoFixture(String admissionYear, String collegeType, String college, String mail) {
-        this.admissionYear = admissionYear;
+    CollegeInfoFixture(Code collegeCode, CollegeType collegeType, String admissionYear) {
+        this.collegeCode = collegeCode;
         this.collegeType = collegeType;
-        this.college = college;
-        this.mail = mail;
+        this.admissionYear = admissionYear;
     }
 
     public CollegeInfo create() {
-        return null;
-    }
-
-    public CollegeInfoRequestDto createCollegeInfoDto() {
-        return CollegeInfoRequestDto.builder()
-            .admissionYear(this.admissionYear)
-            .college(this.college)
+        return CollegeInfo.builder()
+            .collegeCode(this.collegeCode)
             .collegeType(this.collegeType)
+            .admissionYear(this.admissionYear)
             .build();
-    }
-
-    public String getAdmissionYear() {
-        return admissionYear;
-    }
-
-    public String getCollegeType() {
-        return collegeType;
-    }
-
-    public String getCollege() {
-        return college;
-    }
-
-    public String getMail() {
-        return mail;
     }
 }

--- a/src/test/java/com/e2i/wemeet/support/fixture/CollegeInfoFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/CollegeInfoFixture.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 public enum CollegeInfoFixture {
-    BASIC(null, CollegeType.ENGINEERING, "20"),
+    ENGINERRING(null, CollegeType.ENGINEERING, "20"),
     KOREA(CodeFixture.KOREA_UNIVERSITY.create(), CollegeType.ENGINEERING, "18"),
     ANYANG(CodeFixture.ANYANG_UNIVERSITY.create(), CollegeType.SOCIAL, "17"),
     WOMAN(CodeFixture.WOMANS_UNIVERSITY.create(), CollegeType.ARTS, "23"),

--- a/src/test/java/com/e2i/wemeet/support/fixture/MeetingRequestFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MeetingRequestFixture.java
@@ -1,0 +1,8 @@
+package com.e2i.wemeet.support.fixture;
+
+import lombok.Getter;
+
+@Getter
+public enum MeetingRequestFixture {
+
+}

--- a/src/test/java/com/e2i/wemeet/support/fixture/MeetingRequestFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MeetingRequestFixture.java
@@ -1,8 +1,30 @@
 package com.e2i.wemeet.support.fixture;
 
+import com.e2i.wemeet.domain.meeting.MeetingRequest;
+import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
+import com.e2i.wemeet.domain.team.Team;
 import lombok.Getter;
 
 @Getter
 public enum MeetingRequestFixture {
+    BASIC_REQUEST("재미있게 놀아요!");
 
+    private final String message;
+
+    MeetingRequestFixture(final String message) {
+        this.message = message;
+    }
+
+    public MeetingRequest create(Team team, Team partnerTeam) {
+        return createBuilder(team, partnerTeam)
+            .build();
+    }
+
+    private MeetingRequest.MeetingRequestBuilder createBuilder(Team team, Team partnerTeam) {
+        return MeetingRequest.builder()
+            .team(team)
+            .partnerTeam(partnerTeam)
+            .acceptStatus(AcceptStatus.PENDING)
+            .message(this.message);
+    }
 }

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -4,10 +4,12 @@ import static com.e2i.wemeet.support.fixture.CollegeInfoFixture.ANYANG;
 import static com.e2i.wemeet.support.fixture.CollegeInfoFixture.KOREA;
 import static com.e2i.wemeet.support.fixture.CollegeInfoFixture.WOMAN;
 
+import com.e2i.wemeet.domain.code.Code;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.data.CollegeInfo;
 import com.e2i.wemeet.domain.member.data.Gender;
 import com.e2i.wemeet.domain.member.data.Mbti;
+import com.e2i.wemeet.domain.member.data.ProfileImage;
 import com.e2i.wemeet.domain.member.data.Role;
 import com.e2i.wemeet.dto.request.member.CreateMemberRequestDto;
 import com.e2i.wemeet.dto.request.member.ModifyMemberRequestDto;
@@ -60,9 +62,17 @@ public enum MemberFixture {
     }
 
     public Member create() {
-        Member member = createBuilder()
+        return createBuilder()
             .build();
-        return member;
+    }
+
+    // 대학 코드를 입력하여 생성
+    public Member create(Code collegeCode) {
+        CollegeInfo collegeInfoFixture = CollegeInfoFixture.BASIC.create(collegeCode);
+
+        return createBuilder()
+            .collegeInfo(collegeInfoFixture)
+            .build();
     }
 
     public Member create_with_id(final Long memberId) {
@@ -98,7 +108,17 @@ public enum MemberFixture {
     }
 
     private Member.MemberBuilder createBuilder() {
-        return Member.builder();
+        return Member.builder()
+            .nickname(this.nickname)
+            .gender(this.gender)
+            .phoneNumber(this.phoneNumber)
+            .email(this.email)
+            .collegeInfo(this.collegeInfo)
+            .mbti(this.mbti)
+            .credit(this.credit)
+            .imageAuth(this.imageAuth)
+            .profileImage(new ProfileImage(this.basicUrl, this.lowUrl))
+            .role(this.role);
     }
 
     public CreateMemberRequestDto createMemberRequestDto() {

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -21,16 +21,16 @@ import lombok.Getter;
 // TODO :: service refactoring
 @Getter
 public enum MemberFixture {
-    KAI("kai", Gender.MAN, "+821056785678", "2017e7024@as.ac.kr",
+    KAI("kai", Gender.MAN, "+821011112222", "2017e7024@as.ac.kr",
         ANYANG.create(), Mbti.INFJ, 100, false,
         "/v1/asdf", "/v1/idwq", Role.USER),
-    RIM("rim", Gender.WOMAN, "+821056785678", "2019a24@gad.ac.kr",
+    RIM("rim", Gender.WOMAN, "+821098764444", "2019a24@gad.ac.kr",
         WOMAN.create(), Mbti.ISFJ, 100, false,
         "/v1/asdf", "/v1/idwq", Role.USER),
-    SEYUN("seyun", Gender.MAN, "+821056785678", "2020a234@ad.ac.kr",
+    SEYUN("seyun", Gender.MAN, "+821090908888", "2020a234@ad.ac.kr",
         KOREA.create(), Mbti.ENFJ, 100, false,
         "/v1/asdf", "/v1/idwq", Role.USER),
-    JEONGYEOL("jeongyeol", Gender.MAN, "+821056785678", "2014p13@pe.ac.kr",
+    JEONGYEOL("jeongyeol", Gender.MAN, "+8210333344444", "2014p13@pe.ac.kr",
         KOREA.create(), Mbti.ESFJ, 100, false,
         "/v1/asdf", "/v1/idwq", Role.USER);
 
@@ -68,7 +68,7 @@ public enum MemberFixture {
 
     // 대학 코드를 입력하여 생성
     public Member create(Code collegeCode) {
-        CollegeInfo collegeInfoFixture = CollegeInfoFixture.BASIC.create(collegeCode);
+        CollegeInfo collegeInfoFixture = CollegeInfoFixture.ENGINERRING.create(collegeCode);
 
         return createBuilder()
             .collegeInfo(collegeInfoFixture)

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -1,8 +1,8 @@
 package com.e2i.wemeet.support.fixture;
 
-import static com.e2i.wemeet.support.fixture.CollegeInfoFixture.ANYANG_COLLEGE;
-import static com.e2i.wemeet.support.fixture.CollegeInfoFixture.KOREA_COLLEGE;
-import static com.e2i.wemeet.support.fixture.CollegeInfoFixture.SEOULWOMEN_COLLEGE;
+import static com.e2i.wemeet.support.fixture.CollegeInfoFixture.ANYANG;
+import static com.e2i.wemeet.support.fixture.CollegeInfoFixture.KOREA;
+import static com.e2i.wemeet.support.fixture.CollegeInfoFixture.WOMAN;
 
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.data.CollegeInfo;
@@ -14,55 +14,54 @@ import com.e2i.wemeet.dto.request.member.ModifyMemberRequestDto;
 import com.e2i.wemeet.dto.response.member.MemberDetailResponseDto;
 import com.e2i.wemeet.dto.response.member.MemberInfoResponseDto;
 import java.lang.reflect.Field;
+import lombok.Getter;
 
 // TODO :: service refactoring
+@Getter
 public enum MemberFixture {
-    KAI(1L, "4100", "kai", Gender.MAN, "+821012341234",
-        ANYANG_COLLEGE.create(), Mbti.INFJ, "안녕하세요", 100, Role.USER, false),
+    KAI("kai", Gender.MAN, "+821056785678", "2017e7024@as.ac.kr",
+        ANYANG.create(), Mbti.INFJ, 100, false,
+        "/v1/asdf", "/v1/idwq", Role.USER),
+    RIM("rim", Gender.WOMAN, "+821056785678", "2019a24@gad.ac.kr",
+        WOMAN.create(), Mbti.ISFJ, 100, false,
+        "/v1/asdf", "/v1/idwq", Role.USER),
+    SEYUN("seyun", Gender.MAN, "+821056785678", "2020a234@ad.ac.kr",
+        KOREA.create(), Mbti.ENFJ, 100, false,
+        "/v1/asdf", "/v1/idwq", Role.USER),
+    JEONGYEOL("jeongyeol", Gender.MAN, "+821056785678", "2014p13@pe.ac.kr",
+        KOREA.create(), Mbti.ESFJ, 100, false,
+        "/v1/asdf", "/v1/idwq", Role.USER);
 
-    RIM(2L, "4101", "rim", Gender.WOMAN, "+821056785678",
-        KOREA_COLLEGE.create(), Mbti.INFJ, "안녕하세요", 100, Role.USER, false),
-
-    SEYUN(3L, "4102", "seyun", Gender.MAN, "+821056785628",
-        SEOULWOMEN_COLLEGE.create(), Mbti.INFJ, "안녕하세요", 100, Role.MANAGER, true),
-
-    JEONGYEOL(4L, "4103", "10cm", Gender.WOMAN, "+821056783678",
-        KOREA_COLLEGE.create(), Mbti.INFJ, "안녕하세요", 100, Role.USER, true);
-
-    private final Long memberId;
-    private final String memberCode;
     private final String nickname;
     private final Gender gender;
     private final String phoneNumber;
+    private final String email;
     private final CollegeInfo collegeInfo;
     private final Mbti mbti;
-    private final String introduction;
-    private final int credit;
+    private final Integer credit;
+    private final Boolean imageAuth;
+    private final String basicUrl;
+    private final String lowUrl;
     private final Role role;
 
-    private final boolean imageAuth;
-
-    MemberFixture(Long memberId, String memberCode, String nickname, Gender gender,
-        String phoneNumber,
-        CollegeInfo collegeInfo, Mbti mbti, String introduction, int credit,
-        Role role, boolean imageAuth) {
-        this.memberId = memberId;
-        this.memberCode = memberCode;
+    MemberFixture(String nickname, Gender gender, String phoneNumber, String email, CollegeInfo collegeInfo, Mbti mbti, Integer credit,
+        Boolean imageAuth, String basicUrl, String lowUrl, Role role) {
         this.nickname = nickname;
         this.gender = gender;
         this.phoneNumber = phoneNumber;
+        this.email = email;
         this.collegeInfo = collegeInfo;
         this.mbti = mbti;
-        this.introduction = introduction;
         this.credit = credit;
-        this.role = role;
         this.imageAuth = imageAuth;
+        this.basicUrl = basicUrl;
+        this.lowUrl = lowUrl;
+        this.role = role;
     }
 
     public Member create() {
         Member member = createBuilder()
             .build();
-        setMemberId(this.memberId, member);
         return member;
     }
 
@@ -107,7 +106,6 @@ public enum MemberFixture {
             .nickname(this.nickname)
             .gender(this.gender.toString())
             .phoneNumber(this.phoneNumber)
-            .collegeInfo(ANYANG_COLLEGE.createCollegeInfoDto())
             .mbti("ESTJ")
             .introduction("hello!!").build();
     }
@@ -118,9 +116,7 @@ public enum MemberFixture {
             .nickname(this.nickname)
             .gender(this.gender)
             .mbti(this.mbti)
-            .collegeType(this.collegeInfo.getCollegeType())
             .admissionYear(this.collegeInfo.getAdmissionYear())
-            .introduction(this.introduction)
             .build();
     }
 
@@ -135,51 +131,10 @@ public enum MemberFixture {
     public MemberInfoResponseDto createMemberInfoResponseDto() {
         return MemberInfoResponseDto.builder()
             .nickname(this.nickname)
-            .memberCode(this.memberCode)
             .profileImage("profileImage Key")
             .univAuth(true)
             .imageAuth(false)
             .build();
-    }
-
-    public Long getMemberId() {
-        return memberId;
-    }
-
-    public String getMemberCode() {
-        return memberCode;
-    }
-
-    public String getNickname() {
-        return nickname;
-    }
-
-    public Gender getGender() {
-        return gender;
-    }
-
-    public String getPhoneNumber() {
-        return phoneNumber;
-    }
-
-    public CollegeInfo getCollegeInfo() {
-        return collegeInfo;
-    }
-
-    public Mbti getMbti() {
-        return mbti;
-    }
-
-    public String getIntroduction() {
-        return introduction;
-    }
-
-    public int getCredit() {
-        return credit;
-    }
-
-    public Role getRole() {
-        return role;
     }
 
     private void setMemberId(Long memberId, Member member) {

--- a/src/test/java/com/e2i/wemeet/support/fixture/TeamFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/TeamFixture.java
@@ -44,6 +44,14 @@ public enum TeamFixture {
         return team;
     }
 
+    public Team create_with_activity(Member teamLeader, List<TeamMember> teamMembers, AdditionalActivity additionalActivity) {
+        Team team = createBuilder(teamLeader)
+            .additionalActivity(additionalActivity)
+            .build();
+        team.addTeamMembers(teamMembers);
+        return team;
+    }
+
     // TODO :: refactor
     public CreateTeamRequestDto createTeamRequestDto() {
         return CreateTeamRequestDto.builder()

--- a/src/test/java/com/e2i/wemeet/support/fixture/TeamFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/TeamFixture.java
@@ -1,76 +1,47 @@
 package com.e2i.wemeet.support.fixture;
 
 import com.e2i.wemeet.domain.member.Member;
-import com.e2i.wemeet.domain.member.data.Gender;
 import com.e2i.wemeet.domain.team.Team;
 import com.e2i.wemeet.domain.team.data.AdditionalActivity;
+import com.e2i.wemeet.domain.team.data.DrinkWithGame;
+import com.e2i.wemeet.domain.team.data.Region;
+import com.e2i.wemeet.domain.team_member.TeamMember;
 import com.e2i.wemeet.dto.request.team.CreateTeamRequestDto;
 import com.e2i.wemeet.dto.request.team.ModifyTeamRequestDto;
 import com.e2i.wemeet.dto.response.team.MyTeamDetailResponseDto;
 import java.lang.reflect.Field;
+import java.util.List;
 import lombok.Getter;
 
 @Getter
 public enum TeamFixture {
 
-    TEST_TEAM(1L, "df42hg", 3, Gender.MAN, "건대입구", "0", AdditionalActivity.SHOW,
-        "안녕하세요. 저희 팀은 멋쟁이 팀입니다.", MemberFixture.KAI.create()),
-    HONGDAE_TEAM(null, "hongda", 3, null, "홍대 입구", "0", AdditionalActivity.SHOW,
-        "안녕하세요. 홍대 팀 인사올립니다.", null);
+    HONGDAE_TEAM_1(3, Region.HONGDAE, 40, DrinkWithGame.ANY,
+        AdditionalActivity.CAFE, "홍대 팀 1"),
+    ;
 
-    private final Long teamId;
-    private final String teamCode;
-
-    private final int memberCount;
-
-    private final Gender gender;
-
-    private final String region;
-
-    private final String drinkingOption;
-
+    private final Integer memberNum;
+    private final Region region;
+    private final Integer drinkRate;
+    private final DrinkWithGame drinkWithGame;
     private final AdditionalActivity additionalActivity;
-
     private final String introduction;
 
-    private final Member member;
-
-    TeamFixture(Long teamId, String teamCode, int memberCount, Gender gender, String region,
-        String drinkingOption, AdditionalActivity additionalActivity, String introduction,
-        Member member) {
-        this.teamId = teamId;
-        this.teamCode = teamCode;
-        this.memberCount = memberCount;
-        this.gender = gender;
+    TeamFixture(Integer memberNum, Region region, Integer drinkRate, DrinkWithGame drinkWithGame, AdditionalActivity additionalActivity,
+        String introduction) {
+        this.memberNum = memberNum;
         this.region = region;
-        this.drinkingOption = drinkingOption;
+        this.drinkRate = drinkRate;
+        this.drinkWithGame = drinkWithGame;
         this.additionalActivity = additionalActivity;
         this.introduction = introduction;
-        this.member = member;
     }
 
-    public Team create() {
-        Team team = createBuilder()
+    public Team create(Member teamLeader, List<TeamMember> teamMembers) {
+        Team team = createBuilder(teamLeader)
             .build();
-        setTeamId(team, this.teamId);
+        team.addTeamMembers(teamMembers);
         return team;
-    }
-
-    public Team create(Member teamLeader) {
-        return createTeamBuilder(teamLeader)
-            .build();
-    }
-
-    public Team create_with_id(Member teamLeader, Long teamId) {
-        Team team = createTeamBuilder(teamLeader)
-            .build();
-        setTeamId(team, teamId);
-        return team;
-    }
-
-    public Team.TeamBuilder createTeamBuilder(Member member) {
-        return Team.builder()
-            .teamLeader(member);
     }
 
     // TODO :: refactor
@@ -91,8 +62,16 @@ public enum TeamFixture {
             .build();
     }
 
-    private Team.TeamBuilder createBuilder() {
-        return Team.builder();
+    private Team.TeamBuilder createBuilder(final Member teamLeader) {
+        return Team.builder()
+            .teamLeader(teamLeader)
+            .gender(teamLeader.getGender())
+            .memberNum(this.memberNum)
+            .region(this.region)
+            .drinkRate(this.drinkRate)
+            .drinkWithGame(this.drinkWithGame)
+            .additionalActivity(this.additionalActivity)
+            .introduction(this.introduction);
     }
 
     private void setTeamId(Team team, Long teamId) {

--- a/src/test/java/com/e2i/wemeet/support/fixture/TeamMemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/TeamMemberFixture.java
@@ -1,0 +1,58 @@
+package com.e2i.wemeet.support.fixture;
+
+import com.e2i.wemeet.domain.member.data.CollegeInfo;
+import com.e2i.wemeet.domain.member.data.Mbti;
+import com.e2i.wemeet.domain.team_member.TeamMember;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public enum TeamMemberFixture {
+    // MAN
+    TOM(CollegeInfoFixture.KOREA.create(), Mbti.ENFJ),
+    WILSON(CollegeInfoFixture.KOREA.create(), Mbti.ENFP),
+    BENJAMIN(CollegeInfoFixture.INHA.create(), Mbti.ESFJ),
+    LIAM(CollegeInfoFixture.ANYANG.create(), Mbti.ESFP),
+    OLIVER(CollegeInfoFixture.INHA.create(), Mbti.INTJ),
+    JAMES(CollegeInfoFixture.ANYANG.create(), Mbti.INTP),
+    NOAH(CollegeInfoFixture.KOREA.create(), Mbti.INFJ),
+
+    // WOMAN
+    OLIVIA(CollegeInfoFixture.WOMAN.create(), Mbti.INFP),
+    RACHEL(CollegeInfoFixture.INHA.create(), Mbti.INFJ),
+    EMMA(CollegeInfoFixture.WOMAN.create(), Mbti.ENFP),
+    ELIJAH(CollegeInfoFixture.ANYANG.create(), Mbti.ENFJ),
+    ELLI(CollegeInfoFixture.WOMAN.create(), Mbti.ENTJ),
+    ;
+
+    private final CollegeInfo collegeInfo;
+    private final Mbti mbti;
+
+    TeamMemberFixture(CollegeInfo collegeInfo, Mbti mbti) {
+        this.collegeInfo = collegeInfo;
+        this.mbti = mbti;
+    }
+
+    public TeamMember create() {
+        return TeamMember.builder()
+            .collegeInfo(this.collegeInfo)
+            .mbti(this.mbti)
+            .build();
+    }
+
+    public static List<TeamMember> create_3_man() {
+        return List.of(
+            TOM.create(),
+            WILSON.create(),
+            BENJAMIN.create()
+        );
+    }
+
+    public static List<TeamMember> create_3_woman() {
+        return List.of(
+            OLIVIA.create(),
+            RACHEL.create(),
+            EMMA.create()
+        );
+    }
+}

--- a/src/test/java/com/e2i/wemeet/support/fixture/code/CodeFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/code/CodeFixture.java
@@ -1,0 +1,66 @@
+package com.e2i.wemeet.support.fixture.code;
+
+import static com.e2i.wemeet.support.fixture.code.GroupCodeFixture.COLLEGE_CODE;
+
+import com.e2i.wemeet.domain.code.Code;
+import com.e2i.wemeet.domain.code.CodePk;
+import com.e2i.wemeet.domain.code.GroupCode;
+import com.e2i.wemeet.support.config.ReflectionUtils;
+
+public enum CodeFixture {
+    // COLLEGE CODE
+    SEOUL_UNIVERSITY(COLLEGE_CODE.create(), "001", "대학교"),
+    KOREA_UNIVERSITY(COLLEGE_CODE.create(), "002", "고려대학교"),
+    YONSEI_UNIVERSITY(COLLEGE_CODE.create(), "003", "연세대학교"),
+    HANYANG_UNIVERSITY(COLLEGE_CODE.create(), "004", "한양대학교"),
+    SOGANG_UNIVERSITY(COLLEGE_CODE.create(), "005", "서강대학교"),
+    SANGMYUNG_UNIVERSITY(COLLEGE_CODE.create(), "006", "상명대학교"),
+    WOMANS_UNIVERSITY(COLLEGE_CODE.create(), "007", "여자대학교"),
+    KYUNGHEE_UNIVERSITY(COLLEGE_CODE.create(), "008", "경희대학교"),
+    ANYANG_UNIVERSITY(COLLEGE_CODE.create(), "009", "안양대학교"),
+    INCHEON_UNIVERSITY(COLLEGE_CODE.create(), "010", "인천대학교"),
+    INHA_UNIVERSITY(COLLEGE_CODE.create(), "011", "인하대학교"),
+
+    // OTHER CODE
+    ;
+
+    private final GroupCode groupCode;
+    private final String codeId;
+    private final String value;
+
+    CodeFixture(GroupCode groupCode, String codeId, String value) {
+        this.groupCode = groupCode;
+        this.codeId = codeId;
+        this.value = value;
+    }
+
+    public Code create() {
+        CodePk codePk = createCodePk(this.codeId, this.groupCode.getGroupCodeId());
+
+        Code code = ReflectionUtils.createInstance(Code.class);
+        ReflectionUtils.setFieldValue(code, "codePk", codePk);
+        ReflectionUtils.setFieldValue(code, "value", this.value);
+        ReflectionUtils.setFieldValue(code, "groupCode", this.groupCode);
+
+        return code;
+    }
+
+    public Code create(final GroupCode groupCode) {
+        CodePk codePk = createCodePk(this.codeId, groupCode.getGroupCodeId());
+
+        Code code = ReflectionUtils.createInstance(Code.class);
+        ReflectionUtils.setFieldValue(code, "codePk", codePk);
+        ReflectionUtils.setFieldValue(code, "value", this.value);
+        ReflectionUtils.setFieldValue(code, "groupCode", groupCode);
+
+        return code;
+    }
+
+    private CodePk createCodePk(final String codeId, final String groupCodeId) {
+        CodePk codePk = ReflectionUtils.createInstance(CodePk.class);
+        ReflectionUtils.setFieldValue(codePk, "codeId", codeId);
+        ReflectionUtils.setFieldValue(codePk, "groupCodeId", groupCodeId);
+
+        return codePk;
+    }
+}

--- a/src/test/java/com/e2i/wemeet/support/fixture/code/CodeFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/code/CodeFixture.java
@@ -26,34 +26,24 @@ public enum CodeFixture {
 
     private final GroupCode groupCode;
     private final String codeId;
-    private final String value;
+    private final String codeValue;
 
-    CodeFixture(GroupCode groupCode, String codeId, String value) {
+    CodeFixture(GroupCode groupCode, String codeId, String codeValue) {
         this.groupCode = groupCode;
         this.codeId = codeId;
-        this.value = value;
+        this.codeValue = codeValue;
     }
 
     public Code create() {
         CodePk codePk = createCodePk(this.codeId, this.groupCode.getGroupCodeId());
 
-        Code code = ReflectionUtils.createInstance(Code.class);
-        ReflectionUtils.setFieldValue(code, "codePk", codePk);
-        ReflectionUtils.setFieldValue(code, "value", this.value);
-        ReflectionUtils.setFieldValue(code, "groupCode", this.groupCode);
-
-        return code;
+        return createCode(codePk, this.groupCode);
     }
 
     public Code create(final GroupCode groupCode) {
         CodePk codePk = createCodePk(this.codeId, groupCode.getGroupCodeId());
 
-        Code code = ReflectionUtils.createInstance(Code.class);
-        ReflectionUtils.setFieldValue(code, "codePk", codePk);
-        ReflectionUtils.setFieldValue(code, "value", this.value);
-        ReflectionUtils.setFieldValue(code, "groupCode", groupCode);
-
-        return code;
+        return createCode(codePk, groupCode);
     }
 
     private CodePk createCodePk(final String codeId, final String groupCodeId) {
@@ -62,5 +52,13 @@ public enum CodeFixture {
         ReflectionUtils.setFieldValue(codePk, "groupCodeId", groupCodeId);
 
         return codePk;
+    }
+
+    private Code createCode(CodePk codePk, GroupCode groupCode) {
+        Code code = ReflectionUtils.createInstance(Code.class);
+        ReflectionUtils.setFieldValue(code, "codePk", codePk);
+        ReflectionUtils.setFieldValue(code, "codeValue", this.codeValue);
+        ReflectionUtils.setFieldValue(code, "groupCode", groupCode);
+        return code;
     }
 }

--- a/src/test/java/com/e2i/wemeet/support/fixture/code/GroupCodeFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/code/GroupCodeFixture.java
@@ -1,0 +1,29 @@
+package com.e2i.wemeet.support.fixture.code;
+
+import com.e2i.wemeet.domain.code.GroupCode;
+import com.e2i.wemeet.support.config.ReflectionUtils;
+import lombok.Getter;
+
+@Getter
+public enum GroupCodeFixture {
+    COLLEGE_CODE("CE", "College", "대학교명");
+
+    private final String groupCodeId;
+    private final String name;
+    private final String description;
+
+    GroupCodeFixture(String groupCodeId, String name, String description) {
+        this.groupCodeId = groupCodeId;
+        this.name = name;
+        this.description = description;
+    }
+
+    public GroupCode create() {
+        GroupCode groupCode = ReflectionUtils.createInstance(GroupCode.class);
+        ReflectionUtils.setFieldValue(groupCode, "groupCodeId", this.groupCodeId);
+        ReflectionUtils.setFieldValue(groupCode, "name", this.name);
+        ReflectionUtils.setFieldValue(groupCode, "description", this.description);
+
+        return groupCode;
+    }
+}


### PR DESCRIPTION
## Related Issue
#80 

## Description
- Repository 계층의 단위 테스트를 위한 AbstractRepositoryUnitTest 추상 클래스 추가
- 미리 정의한 Enum 상수 값 추가
- Converter 구현 & 적용
- Converter 테스트 작성
  - Test Fixture 변경
  - p6spy 의존성 추가 (콘솔에 쿼리 파라미터 값 출력)
- 기타 Entity 관련 오류 수정

## Screenshots (if appropriate):
- Fixture을 사용한 Test Entity 생성 예시
```java
public class JpaAttributeConverterTest extends AbstractRepositoryUnitTest {

    @Autowired
    private MemberRepository memberRepository;

    @Autowired
    private MeetingRequestRepository meetingRequestRepository;

    @Autowired
    private TeamRepository teamRepository;

    @Nested
    class AcceptStatusConverterTest {

        @DisplayName("데이터 베이스에 요청을 전송할 때, accept_status field에 key 값이 바인딩된다.")
        @Test
        void convertToDatabaseColumn() {
            // given
            Member rim = memberRepository.save(MemberFixture.RIM.create(WOMANS_CODE));
            Member kai = memberRepository.save(MemberFixture.KAI.create(ANYANG_CODE));

            Team womanTeam = teamRepository.save(
                TeamFixture.HONGDAE_TEAM_1.create(rim, TeamMemberFixture.create_3_woman())
            );
            Team manTeam = teamRepository.save(
                TeamFixture.HONGDAE_TEAM_1.create(kai, TeamMemberFixture.create_3_man())
            );

            MeetingRequest meetingRequest = meetingRequestRepository.save(
                MeetingRequestFixture.BASIC_REQUEST.create(womanTeam, manTeam)
            );
            ...
        }
   }
}

```
