### PR TITLE
feat(code): add initialize code sql on local envirionment

### DIFF
--- a/src/main/java/com/e2i/wemeet/domain/code/CodeRepository.java
+++ b/src/main/java/com/e2i/wemeet/domain/code/CodeRepository.java
@@ -1,7 +1,10 @@
 package com.e2i.wemeet.domain.code;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CodeRepository extends JpaRepository<Code, CodePk> {
+
+    Optional<Code> findByCodeValue(String codeValue);
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,14 +31,24 @@ spring:
     activate:
       on-profile: local
     import: sub/local/application-db.yml
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:sub/local/data.sql
 ---
 spring:
   config:
     activate:
       on-profile: dev
     import: sub/dev/application-db.yml
+  sql:
+    init:
+      mode: never
 ---
 spring:
   config:
     activate:
       on-profile: prod
+  sql:
+    init:
+      mode: never

--- a/src/test/java/com/e2i/wemeet/domain/code/CodeRepositoryTest.java
+++ b/src/test/java/com/e2i/wemeet/domain/code/CodeRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.e2i.wemeet.domain.code;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.e2i.wemeet.support.config.RepositoryTest;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RepositoryTest
+class CodeRepositoryTest {
+
+    @Autowired
+    private CodeRepository codeRepository;
+
+    @DisplayName("대학교명으로 대학교 코드를 조회할 수 있다.")
+    @Test
+    void findByCodeValue_CollegeCode() {
+        // given
+        String collegeName = "서울대학교";
+
+        // when
+        Optional<Code> collegeCode = codeRepository.findByCodeValue(collegeName);
+
+        // then
+        assertThat(collegeCode).isNotEmpty();
+        assertThat(collegeCode.get().getCodePk().getCodeId()).isEqualTo("001");
+    }
+
+    @DisplayName("대학교명이 존재하지 않으면 대학교 코드를 조회할 수 없다.")
+    @Test
+    void findByCodeValue_invalidCollegeCode() {
+        // given
+        String collegeName = "서운대학교";
+
+        // when
+        Optional<Code> collegeCode = codeRepository.findByCodeValue(collegeName);
+
+        // then
+        assertThat(collegeCode).isEmpty();
+    }
+}

--- a/src/test/java/com/e2i/wemeet/support/config/AbstractRepositoryUnitTest.java
+++ b/src/test/java/com/e2i/wemeet/support/config/AbstractRepositoryUnitTest.java
@@ -2,12 +2,9 @@ package com.e2i.wemeet.support.config;
 
 import com.e2i.wemeet.domain.code.Code;
 import com.e2i.wemeet.domain.code.CodeRepository;
-import com.e2i.wemeet.domain.code.GroupCode;
 import com.e2i.wemeet.domain.code.GroupCodeRepository;
 import com.e2i.wemeet.support.fixture.code.CodeFixture;
-import com.e2i.wemeet.support.fixture.code.GroupCodeFixture;
 import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,18 +30,15 @@ public abstract class AbstractRepositoryUnitTest {
 
     @BeforeEach
     void setUpCode() {
-        GroupCode collegeGroup = groupCodeRepository.save(GroupCodeFixture.COLLEGE_CODE.create());
-
-        KOREA_CODE = codeRepository.save(CodeFixture.KOREA_UNIVERSITY.create(collegeGroup));
-        ANYANG_CODE = codeRepository.save(CodeFixture.ANYANG_UNIVERSITY.create(collegeGroup));
-        INHA_CODE = codeRepository.save(CodeFixture.INHA_UNIVERSITY.create(collegeGroup));
-        WOMANS_CODE = codeRepository.save(CodeFixture.WOMANS_UNIVERSITY.create(collegeGroup));
-        HANYANG_CODE = codeRepository.save(CodeFixture.HANYANG_UNIVERSITY.create(collegeGroup));
-    }
-
-    @AfterEach
-    void cleanUp() {
-        groupCodeRepository.deleteAll();
-        codeRepository.deleteAll();
+        KOREA_CODE = codeRepository.findByCodeValue(CodeFixture.KOREA_UNIVERSITY.getCodeValue())
+            .orElseThrow();
+        ANYANG_CODE = codeRepository.findByCodeValue(CodeFixture.ANYANG_UNIVERSITY.getCodeValue())
+            .orElseThrow();
+        INHA_CODE = codeRepository.findByCodeValue(CodeFixture.INHA_UNIVERSITY.getCodeValue())
+            .orElseThrow();
+        WOMANS_CODE = codeRepository.findByCodeValue(CodeFixture.WOMANS_UNIVERSITY.getCodeValue())
+            .orElseThrow();
+        HANYANG_CODE = codeRepository.findByCodeValue(CodeFixture.HANYANG_UNIVERSITY.getCodeValue())
+            .orElseThrow();
     }
 }

--- a/src/test/java/com/e2i/wemeet/support/fixture/code/CodeFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/code/CodeFixture.java
@@ -9,7 +9,7 @@ import com.e2i.wemeet.support.config.ReflectionUtils;
 
 public enum CodeFixture {
     // COLLEGE CODE
-    SEOUL_UNIVERSITY(COLLEGE_CODE.create(), "001", "대학교"),
+    SEOUL_UNIVERSITY(COLLEGE_CODE.create(), "001", "서울대학교"),
     KOREA_UNIVERSITY(COLLEGE_CODE.create(), "002", "고려대학교"),
     YONSEI_UNIVERSITY(COLLEGE_CODE.create(), "003", "연세대학교"),
     HANYANG_UNIVERSITY(COLLEGE_CODE.create(), "004", "한양대학교"),
@@ -60,5 +60,17 @@ public enum CodeFixture {
         ReflectionUtils.setFieldValue(code, "codeValue", this.codeValue);
         ReflectionUtils.setFieldValue(code, "groupCode", groupCode);
         return code;
+    }
+
+    public GroupCode getGroupCode() {
+        return groupCode;
+    }
+
+    public String getCodeId() {
+        return codeId;
+    }
+
+    public String getCodeValue() {
+        return codeValue;
     }
 }


### PR DESCRIPTION
## Related Issue
#83 

## Description
- 기존 Repository Test에서 매번 Code를 생성하여 Table에 insert하였습니다. 
   - 하지만 코드 데이터가 데이터베이스에 이미 존재할 경우, UNIQUE KEY VIOLATION 예외가 발생하게 됩니다.
- 따라서, local 환경에서만 테스트용 code 데이터를 미리 삽입하여 사용할 수 있도록 data.sql문을 추가하였습니다.

## Screenshots (if appropriate):
### profile - local로 Application Context를 띄울 경우 다음과 같이 코드 데이터가 데이터베이스에 삽입됩니다.

<img width="560" alt="image" src="https://github.com/SWM-E2I/wemeet-backend/assets/99247279/3247eaed-95ee-456c-88c8-49820da2b3a6">
