### PR TITLE
feat(team): Add an API that can look up team details by team ID

### DIFF
--- a/src/main/java/com/e2i/wemeet/controller/team/TeamController.java
+++ b/src/main/java/com/e2i/wemeet/controller/team/TeamController.java
@@ -6,6 +6,7 @@ import com.e2i.wemeet.dto.request.team.CreateTeamRequestDto;
 import com.e2i.wemeet.dto.request.team.UpdateTeamRequestDto;
 import com.e2i.wemeet.dto.response.ResponseDto;
 import com.e2i.wemeet.dto.response.team.MyTeamResponseDto;
+import com.e2i.wemeet.dto.response.team.TeamDetailResponseDto;
 import com.e2i.wemeet.security.manager.IsManager;
 import com.e2i.wemeet.service.team.TeamService;
 import jakarta.validation.Valid;
@@ -13,6 +14,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -52,6 +54,13 @@ public class TeamController {
         MyTeamResponseDto result = teamService.readTeam(memberId);
 
         return ResponseDto.success("Get My Team Detail Success", result);
+    }
+
+    @GetMapping("/{teamId}")
+    public ResponseDto<TeamDetailResponseDto> readTeamById(@PathVariable Long teamId) {
+        TeamDetailResponseDto result = teamService.readByTeamId(teamId);
+
+        return ResponseDto.success("Get Team Detail Success", result);
     }
 
     @IsManager

--- a/src/main/java/com/e2i/wemeet/domain/meeting/MeetingReadRepositoryImpl.java
+++ b/src/main/java/com/e2i/wemeet/domain/meeting/MeetingReadRepositoryImpl.java
@@ -77,7 +77,10 @@ public class MeetingReadRepositoryImpl implements MeetingReadRepository {
                     partnerTeamLeader.nickname.as("partnerLeaderNickname"),
                     partnerTeamLeader.mbti.as("partnerLeaderMbti"),
                     partnerTeamLeader.profileImage.lowUrl.as("partnerLeaderLowProfileUrl"),
-                    code.codeValue.as("partnerLeaderCollegeName")
+                    code.codeValue.as("partnerLeaderCollegeName"),
+                    partnerTeamLeader.collegeInfo.collegeType.as("partnerLeaderCollegeType"),
+                    partnerTeamLeader.collegeInfo.admissionYear.as("partnerLeaderAdmissionYear"),
+                    partnerTeamLeader.profileImage.imageAuth.as("partnerLeaderImageAuth")
                 ))
             .from(meeting)
             // My Team & Partner Team
@@ -160,7 +163,10 @@ public class MeetingReadRepositoryImpl implements MeetingReadRepository {
                 partnerTeamLeader.nickname.as("partnerLeaderNickname"),
                 partnerTeamLeader.mbti.as("partnerLeaderMbti"),
                 partnerTeamLeader.profileImage.lowUrl.as("partnerLeaderLowProfileUrl"),
-                code.codeValue.as("partnerLeaderCollegeName")
+                code.codeValue.as("partnerLeaderCollegeName"),
+                partnerTeamLeader.collegeInfo.collegeType.as("partnerLeaderCollegeType"),
+                partnerTeamLeader.collegeInfo.admissionYear.as("partnerLeaderAdmissionYear"),
+                partnerTeamLeader.profileImage.imageAuth.as("partnerLeaderImageAuth")
             ));
     }
 

--- a/src/main/java/com/e2i/wemeet/domain/member/Member.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/Member.java
@@ -206,5 +206,9 @@ public class Member extends BaseTimeEntity {
     public boolean isProfileImageExists() {
         return this.profileImage != null;
     }
+
+    public String getCollegeName() {
+        return this.collegeInfo.getCollegeCode().getCodeValue();
+    }
 }
 

--- a/src/main/java/com/e2i/wemeet/domain/team/Team.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/Team.java
@@ -134,5 +134,9 @@ public class Team extends BaseTimeEntity {
         this.deletedAt = deletedAt;
         teamLeader.setRole(Role.USER);
     }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
 }
 

--- a/src/main/java/com/e2i/wemeet/domain/team/TeamCustomRepository.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/TeamCustomRepository.java
@@ -1,10 +1,26 @@
 package com.e2i.wemeet.domain.team;
 
 import com.e2i.wemeet.domain.team.data.TeamImageData;
+import com.e2i.wemeet.dto.dsl.TeamInformationDto;
+import com.e2i.wemeet.dto.response.LeaderResponseDto;
 import java.util.List;
+import java.util.Optional;
 
 public interface TeamCustomRepository {
 
+    /*
+     * 팀 이미지 조회
+     * */
+    List<TeamImageData> findTeamImagesByTeamId(Long teamId);
 
-    List<TeamImageData> findTeamWithTeamImages(Long teamId);
+    /*
+     * 팀 리더 조회
+     * */
+    Optional<LeaderResponseDto> findLeaderByTeamId(Long teamId);
+
+    /*
+     * 팀 정보 조회
+     * */
+    Optional<TeamInformationDto> findTeamInformationByTeamId(Long teamId);
+
 }

--- a/src/main/java/com/e2i/wemeet/domain/team/TeamCustomRepositoryImpl.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/TeamCustomRepositoryImpl.java
@@ -1,11 +1,20 @@
 package com.e2i.wemeet.domain.team;
 
+import static com.e2i.wemeet.domain.code.QCode.code;
+import static com.e2i.wemeet.domain.member.QMember.member;
+import static com.e2i.wemeet.domain.team.QTeam.team;
 import static com.e2i.wemeet.domain.team_image.QTeamImage.teamImage;
+import static com.e2i.wemeet.domain.team_member.QTeamMember.teamMember;
 
 import com.e2i.wemeet.domain.team.data.TeamImageData;
+import com.e2i.wemeet.dto.dsl.TeamInformationDto;
+import com.e2i.wemeet.dto.dsl.TeamMemberInformationDto;
+import com.e2i.wemeet.dto.response.LeaderResponseDto;
+import com.e2i.wemeet.exception.notfound.TeamNotFoundException;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -16,12 +25,75 @@ public class TeamCustomRepositoryImpl implements TeamCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<TeamImageData> findTeamWithTeamImages(Long teamId) {
+    public List<TeamImageData> findTeamImagesByTeamId(final Long teamId) {
         return queryFactory
             .select(Projections.constructor(TeamImageData.class, teamImage.teamImageUrl.as("url")))
             .from(teamImage)
             .where(teamImage.team.teamId.eq(teamId))
             .orderBy(teamImage.sequence.asc())
+            .fetch();
+    }
+
+    @Override
+    public Optional<LeaderResponseDto> findLeaderByTeamId(final Long teamId) {
+        return Optional.ofNullable(queryFactory
+            .select(Projections.constructor(LeaderResponseDto.class,
+                    member.memberId.as("leaderId"),
+                    member.nickname,
+                    member.mbti,
+                    code.codeValue.as("collegeName"),
+                    member.collegeInfo.collegeType.as("collegeType"),
+                    member.collegeInfo.admissionYear,
+                    member.profileImage.lowUrl.as("leaderLowProfileImageUrl"),
+                    member.profileImage.imageAuth.as("imageAuth")
+                )
+            )
+            .from(team)
+            .join(team.teamLeader, member)
+            .join(member.collegeInfo.collegeCode, code)
+            .where(team.teamId.eq(teamId))
+            .fetchOne());
+    }
+
+    @Override
+    public Optional<TeamInformationDto> findTeamInformationByTeamId(final Long teamId) {
+        TeamInformationDto teamInformationDto = Optional.ofNullable(queryFactory
+                .select(Projections.constructor(TeamInformationDto.class,
+                    team.teamId,
+                    team.memberNum,
+                    team.region,
+                    team.drinkRate,
+                    team.drinkWithGame,
+                    team.additionalActivity,
+                    team.introduction,
+                    team.deletedAt
+                ))
+                .from(team)
+                .where(team.teamId.eq(teamId))
+                .fetchOne())
+            .orElseThrow(TeamNotFoundException::new);
+
+        List<TeamMemberInformationDto> teamMemberResponseDtos = findTeamMemberResponseDto(teamId);
+        if (teamMemberResponseDtos.isEmpty()) {
+            throw new TeamNotFoundException();
+        }
+        teamInformationDto.setTeamMembers(teamMemberResponseDtos);
+
+        return Optional.of(teamInformationDto);
+    }
+
+    private List<TeamMemberInformationDto> findTeamMemberResponseDto(final Long teamId) {
+        return queryFactory
+            .select(Projections.constructor(TeamMemberInformationDto.class,
+                code.codeValue.as("collegeName"),
+                teamMember.collegeInfo.collegeType,
+                teamMember.collegeInfo.admissionYear,
+                teamMember.mbti
+            ))
+            .from(teamMember)
+            .join(teamMember.collegeInfo.collegeCode, code)
+            .join(teamMember.team, team)
+            .where(team.teamId.eq(teamId))
             .fetch();
     }
 }

--- a/src/main/java/com/e2i/wemeet/domain/team_member/TeamMember.java
+++ b/src/main/java/com/e2i/wemeet/domain/team_member/TeamMember.java
@@ -51,5 +51,9 @@ public class TeamMember extends BaseTimeEntity {
             team.getTeamMembers().add(this);
         }
     }
+
+    public String getCollegeName() {
+        return this.collegeInfo.getCollegeCode().getCodeValue();
+    }
 }
 

--- a/src/main/java/com/e2i/wemeet/dto/dsl/MeetingInformationDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/dsl/MeetingInformationDto.java
@@ -1,5 +1,6 @@
 package com.e2i.wemeet.dto.dsl;
 
+import com.e2i.wemeet.domain.member.data.CollegeType;
 import com.e2i.wemeet.domain.member.data.Mbti;
 import com.e2i.wemeet.domain.team.data.Region;
 import com.querydsl.core.annotations.QueryProjection;
@@ -24,11 +25,15 @@ public class MeetingInformationDto {
     private Mbti partnerLeaderMbti;
     private String partnerLeaderLowProfileUrl;
     private String partnerLeaderCollegeName;
+    private CollegeType partnerLeaderCollegeType;
+    private String partnerLeaderAdmissionYear;
+    private Boolean partnerLeaderImageAuth;
 
     @QueryProjection
     public MeetingInformationDto(Long meetingId, LocalDateTime meetingAcceptTime, boolean isOver, LocalDateTime deletedAt, Long teamId,
-        int memberCount, Region region, Long partnerLeaderId, String partnerLeaderNickname, Mbti partnerLeaderMbti,
-        String partnerLeaderLowProfileUrl, String partnerLeaderCollegeName) {
+        int memberCount,
+        Region region, Long partnerLeaderId, String partnerLeaderNickname, Mbti partnerLeaderMbti, String partnerLeaderLowProfileUrl,
+        String partnerLeaderCollegeName, CollegeType partnerLeaderCollegeType, String partnerLeaderAdmissionYear, Boolean partnerLeaderImageAuth) {
         this.meetingId = meetingId;
         this.meetingAcceptTime = meetingAcceptTime;
         this.isOver = isOver;
@@ -41,6 +46,9 @@ public class MeetingInformationDto {
         this.partnerLeaderMbti = partnerLeaderMbti;
         this.partnerLeaderLowProfileUrl = partnerLeaderLowProfileUrl;
         this.partnerLeaderCollegeName = partnerLeaderCollegeName;
+        this.partnerLeaderCollegeType = partnerLeaderCollegeType;
+        this.partnerLeaderAdmissionYear = partnerLeaderAdmissionYear;
+        this.partnerLeaderImageAuth = partnerLeaderImageAuth;
     }
 
     public boolean isOver() {

--- a/src/main/java/com/e2i/wemeet/dto/dsl/MeetingRequestInformationDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/dsl/MeetingRequestInformationDto.java
@@ -1,6 +1,7 @@
 package com.e2i.wemeet.dto.dsl;
 
 import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
+import com.e2i.wemeet.domain.member.data.CollegeType;
 import com.e2i.wemeet.domain.member.data.Mbti;
 import com.e2i.wemeet.domain.team.data.Region;
 import com.querydsl.core.annotations.QueryProjection;
@@ -26,11 +27,15 @@ public class MeetingRequestInformationDto {
     private Mbti partnerLeaderMbti;
     private String partnerLeaderLowProfileUrl;
     private String partnerLeaderCollegeName;
+    private CollegeType partnerLeaderCollegeType;
+    private String partnerLeaderAdmissionYear;
+    private Boolean partnerLeaderImageAuth;
 
     @QueryProjection
     public MeetingRequestInformationDto(Long meetingRequestId, LocalDateTime requestSentTime, String message, AcceptStatus acceptStatus, Long teamId,
         int memberCount, Region region, LocalDateTime deletedAt, Long partnerLeaderId, String partnerLeaderNickname, Mbti partnerLeaderMbti,
-        String partnerLeaderLowProfileUrl, String partnerLeaderCollegeName) {
+        String partnerLeaderLowProfileUrl, String partnerLeaderCollegeName, CollegeType partnerLeaderCollegeType, String partnerLeaderAdmissionYear,
+        Boolean partnerLeaderImageAuth) {
         this.meetingRequestId = meetingRequestId;
         this.requestSentTime = requestSentTime;
         this.message = message;
@@ -44,6 +49,9 @@ public class MeetingRequestInformationDto {
         this.partnerLeaderMbti = partnerLeaderMbti;
         this.partnerLeaderLowProfileUrl = partnerLeaderLowProfileUrl;
         this.partnerLeaderCollegeName = partnerLeaderCollegeName;
+        this.partnerLeaderCollegeType = partnerLeaderCollegeType;
+        this.partnerLeaderAdmissionYear = partnerLeaderAdmissionYear;
+        this.partnerLeaderImageAuth = partnerLeaderImageAuth;
     }
 
     @Override

--- a/src/main/java/com/e2i/wemeet/dto/dsl/TeamInformationDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/dsl/TeamInformationDto.java
@@ -26,7 +26,7 @@ public class TeamInformationDto {
     private final Boolean isDeleted;
 
     @Builder
-    public TeamInformationDto(Long teamId, Integer memberNum, Region region, DrinkRate drinkRate, List<TeamMember> teamMembers,
+    public TeamInformationDto(Long teamId, Integer memberNum, Region region, DrinkRate drinkRate,
         DrinkWithGame drinkWithGame, AdditionalActivity additionalActivity, String introduction, LocalDateTime deletedAt) {
         this.teamId = teamId;
         this.memberNum = memberNum;
@@ -36,11 +36,10 @@ public class TeamInformationDto {
         this.additionalActivity = additionalActivity;
         this.introduction = introduction;
         this.isDeleted = deletedAt != null;
-        setTeamMember(teamMembers);
     }
 
     public static TeamInformationDto of(Team team) {
-        return TeamInformationDto.builder()
+        TeamInformationDto dto = TeamInformationDto.builder()
             .teamId(team.getTeamId())
             .memberNum(team.getMemberNum())
             .region(team.getRegion())
@@ -49,8 +48,10 @@ public class TeamInformationDto {
             .additionalActivity(team.getAdditionalActivity())
             .introduction(team.getIntroduction())
             .deletedAt(team.getDeletedAt())
-            .teamMembers(team.getTeamMembers())
             .build();
+
+        dto.setTeamMember(team.getTeamMembers());
+        return dto;
     }
 
     public void setTeamMembers(List<TeamMemberInformationDto> teamMembers) {

--- a/src/main/java/com/e2i/wemeet/dto/dsl/TeamInformationDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/dsl/TeamInformationDto.java
@@ -1,0 +1,44 @@
+package com.e2i.wemeet.dto.dsl;
+
+import com.e2i.wemeet.domain.team.data.AdditionalActivity;
+import com.e2i.wemeet.domain.team.data.DrinkRate;
+import com.e2i.wemeet.domain.team.data.DrinkWithGame;
+import com.e2i.wemeet.domain.team.data.Region;
+import com.e2i.wemeet.dto.response.team.TeamMemberResponseDto;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TeamInformationDto {
+
+    private final Long teamId;
+    private List<TeamMemberResponseDto> teamMembers;
+    private final Integer memberNum;
+    private final Region region;
+    private final DrinkRate drinkRate;
+    private final DrinkWithGame drinkWithGame;
+    private final AdditionalActivity additionalActivity;
+    private final String introduction;
+    private final Boolean isDeleted;
+
+    @Builder
+    public TeamInformationDto(Long teamId, Integer memberNum, Region region, DrinkRate drinkRate,
+        DrinkWithGame drinkWithGame, AdditionalActivity additionalActivity, String introduction, LocalDateTime deletedAt) {
+        this.teamId = teamId;
+        this.memberNum = memberNum;
+        this.region = region;
+        this.drinkRate = drinkRate;
+        this.drinkWithGame = drinkWithGame;
+        this.additionalActivity = additionalActivity;
+        this.introduction = introduction;
+        this.isDeleted = deletedAt != null;
+    }
+
+    public void setTeamMembers(List<TeamMemberInformationDto> teamMembers) {
+        this.teamMembers = teamMembers.stream()
+            .map(TeamMemberInformationDto::toTeamMemberResponseDto)
+            .toList();
+    }
+}

--- a/src/main/java/com/e2i/wemeet/dto/dsl/TeamInformationDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/dsl/TeamInformationDto.java
@@ -1,9 +1,11 @@
 package com.e2i.wemeet.dto.dsl;
 
+import com.e2i.wemeet.domain.team.Team;
 import com.e2i.wemeet.domain.team.data.AdditionalActivity;
 import com.e2i.wemeet.domain.team.data.DrinkRate;
 import com.e2i.wemeet.domain.team.data.DrinkWithGame;
 import com.e2i.wemeet.domain.team.data.Region;
+import com.e2i.wemeet.domain.team_member.TeamMember;
 import com.e2i.wemeet.dto.response.team.TeamMemberResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,7 +26,7 @@ public class TeamInformationDto {
     private final Boolean isDeleted;
 
     @Builder
-    public TeamInformationDto(Long teamId, Integer memberNum, Region region, DrinkRate drinkRate,
+    public TeamInformationDto(Long teamId, Integer memberNum, Region region, DrinkRate drinkRate, List<TeamMember> teamMembers,
         DrinkWithGame drinkWithGame, AdditionalActivity additionalActivity, String introduction, LocalDateTime deletedAt) {
         this.teamId = teamId;
         this.memberNum = memberNum;
@@ -34,11 +36,32 @@ public class TeamInformationDto {
         this.additionalActivity = additionalActivity;
         this.introduction = introduction;
         this.isDeleted = deletedAt != null;
+        setTeamMember(teamMembers);
+    }
+
+    public static TeamInformationDto of(Team team) {
+        return TeamInformationDto.builder()
+            .teamId(team.getTeamId())
+            .memberNum(team.getMemberNum())
+            .region(team.getRegion())
+            .drinkRate(team.getDrinkRate())
+            .drinkWithGame(team.getDrinkWithGame())
+            .additionalActivity(team.getAdditionalActivity())
+            .introduction(team.getIntroduction())
+            .deletedAt(team.getDeletedAt())
+            .teamMembers(team.getTeamMembers())
+            .build();
     }
 
     public void setTeamMembers(List<TeamMemberInformationDto> teamMembers) {
         this.teamMembers = teamMembers.stream()
             .map(TeamMemberInformationDto::toTeamMemberResponseDto)
+            .toList();
+    }
+
+    private void setTeamMember(List<TeamMember> teamMembers) {
+        this.teamMembers = teamMembers.stream()
+            .map(TeamMemberResponseDto::of)
             .toList();
     }
 }

--- a/src/main/java/com/e2i/wemeet/dto/dsl/TeamMemberInformationDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/dsl/TeamMemberInformationDto.java
@@ -1,0 +1,22 @@
+package com.e2i.wemeet.dto.dsl;
+
+import com.e2i.wemeet.domain.member.data.CollegeType;
+import com.e2i.wemeet.domain.member.data.Mbti;
+import com.e2i.wemeet.dto.response.team.TeamMemberResponseDto;
+
+public record TeamMemberInformationDto(
+    String collegeName,
+    CollegeType collegeType,
+    String admissionYear,
+    Mbti mbti
+) {
+
+    public TeamMemberResponseDto toTeamMemberResponseDto() {
+        return TeamMemberResponseDto.builder()
+            .college(this.collegeName)
+            .collegeType(this.collegeType.name())
+            .admissionYear(this.admissionYear)
+            .mbti(this.mbti)
+            .build();
+    }
+}

--- a/src/main/java/com/e2i/wemeet/dto/response/LeaderResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/LeaderResponseDto.java
@@ -18,12 +18,12 @@ public record LeaderResponseDto(
 
 ) {
 
-    public static LeaderResponseDto of(final Member leader, final String collegeName) {
+    public static LeaderResponseDto of(final Member leader) {
         return new LeaderResponseDto(
             leader.getMemberId(),
             leader.getNickname(),
             leader.getMbti(),
-            collegeName,
+            leader.getCollegeInfo().getCollegeCode().getCodeValue(),
             leader.getCollegeInfo().getCollegeType(),
             leader.getCollegeInfo().getAdmissionYear(),
             leader.getProfileImage().getLowUrl(),
@@ -57,4 +57,17 @@ public record LeaderResponseDto(
         );
     }
 
+    @Override
+    public String toString() {
+        return "LeaderResponseDto{" +
+            "leaderId=" + leaderId +
+            ", nickname='" + nickname + '\'' +
+            ", mbti=" + mbti +
+            ", collegeName='" + collegeName + '\'' +
+            ", collegeType=" + collegeType +
+            ", admissionYear='" + admissionYear + '\'' +
+            ", leaderLowProfileImageUrl='" + leaderLowProfileImageUrl + '\'' +
+            ", imageAuth=" + imageAuth +
+            '}';
+    }
 }

--- a/src/main/java/com/e2i/wemeet/dto/response/LeaderResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/LeaderResponseDto.java
@@ -1,4 +1,4 @@
-package com.e2i.wemeet.dto.response.meeting;
+package com.e2i.wemeet.dto.response;
 
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.data.CollegeType;

--- a/src/main/java/com/e2i/wemeet/dto/response/meeting/AcceptedMeetingResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/meeting/AcceptedMeetingResponseDto.java
@@ -2,6 +2,7 @@ package com.e2i.wemeet.dto.response.meeting;
 
 import com.e2i.wemeet.domain.team.data.Region;
 import com.e2i.wemeet.dto.dsl.MeetingInformationDto;
+import com.e2i.wemeet.dto.response.LeaderResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;

--- a/src/main/java/com/e2i/wemeet/dto/response/meeting/LeaderResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/meeting/LeaderResponseDto.java
@@ -1,6 +1,7 @@
 package com.e2i.wemeet.dto.response.meeting;
 
 import com.e2i.wemeet.domain.member.Member;
+import com.e2i.wemeet.domain.member.data.CollegeType;
 import com.e2i.wemeet.domain.member.data.Mbti;
 import com.e2i.wemeet.dto.dsl.MeetingInformationDto;
 import com.e2i.wemeet.dto.dsl.MeetingRequestInformationDto;
@@ -10,7 +11,10 @@ public record LeaderResponseDto(
     String nickname,
     Mbti mbti,
     String collegeName,
-    String leaderLowProfileImageUrl
+    CollegeType collegeType,
+    String admissionYear,
+    String leaderLowProfileImageUrl,
+    Boolean imageAuth
 
 ) {
 
@@ -20,7 +24,10 @@ public record LeaderResponseDto(
             leader.getNickname(),
             leader.getMbti(),
             collegeName,
-            leader.getProfileImage().getLowUrl()
+            leader.getCollegeInfo().getCollegeType(),
+            leader.getCollegeInfo().getAdmissionYear(),
+            leader.getProfileImage().getLowUrl(),
+            leader.getProfileImage().getImageAuth()
         );
     }
 
@@ -30,7 +37,10 @@ public record LeaderResponseDto(
             meetingInformationDto.getPartnerLeaderNickname(),
             meetingInformationDto.getPartnerLeaderMbti(),
             meetingInformationDto.getPartnerLeaderCollegeName(),
-            meetingInformationDto.getPartnerLeaderLowProfileUrl()
+            meetingInformationDto.getPartnerLeaderCollegeType(),
+            meetingInformationDto.getPartnerLeaderAdmissionYear(),
+            meetingInformationDto.getPartnerLeaderLowProfileUrl(),
+            meetingInformationDto.getPartnerLeaderImageAuth()
         );
     }
 
@@ -40,7 +50,10 @@ public record LeaderResponseDto(
             meetingRequestInformationDto.getPartnerLeaderNickname(),
             meetingRequestInformationDto.getPartnerLeaderMbti(),
             meetingRequestInformationDto.getPartnerLeaderCollegeName(),
-            meetingRequestInformationDto.getPartnerLeaderLowProfileUrl()
+            meetingRequestInformationDto.getPartnerLeaderCollegeType(),
+            meetingRequestInformationDto.getPartnerLeaderAdmissionYear(),
+            meetingRequestInformationDto.getPartnerLeaderLowProfileUrl(),
+            meetingRequestInformationDto.getPartnerLeaderImageAuth()
         );
     }
 

--- a/src/main/java/com/e2i/wemeet/dto/response/meeting/ReceivedMeetingResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/meeting/ReceivedMeetingResponseDto.java
@@ -3,6 +3,7 @@ package com.e2i.wemeet.dto.response.meeting;
 import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
 import com.e2i.wemeet.domain.team.data.Region;
 import com.e2i.wemeet.dto.dsl.MeetingRequestInformationDto;
+import com.e2i.wemeet.dto.response.LeaderResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;

--- a/src/main/java/com/e2i/wemeet/dto/response/meeting/SentMeetingResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/meeting/SentMeetingResponseDto.java
@@ -3,6 +3,7 @@ package com.e2i.wemeet.dto.response.meeting;
 import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
 import com.e2i.wemeet.domain.team.data.Region;
 import com.e2i.wemeet.dto.dsl.MeetingRequestInformationDto;
+import com.e2i.wemeet.dto.response.LeaderResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;

--- a/src/main/java/com/e2i/wemeet/dto/response/team/TeamDetailResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/team/TeamDetailResponseDto.java
@@ -1,0 +1,59 @@
+package com.e2i.wemeet.dto.response.team;
+
+import com.e2i.wemeet.domain.team.data.AdditionalActivity;
+import com.e2i.wemeet.domain.team.data.DrinkRate;
+import com.e2i.wemeet.domain.team.data.DrinkWithGame;
+import com.e2i.wemeet.domain.team.data.Region;
+import com.e2i.wemeet.dto.dsl.TeamInformationDto;
+import com.e2i.wemeet.dto.response.LeaderResponseDto;
+import java.util.List;
+
+public record TeamDetailResponseDto(
+    Long teamId,
+    Boolean isDeleted,
+    Integer memberNum,
+    Region region,
+    DrinkRate drinkRate,
+    DrinkWithGame drinkWithGame,
+    AdditionalActivity additionalActivity,
+    String introduction,
+    List<String> teamImageUrls,
+    List<TeamMemberResponseDto> teamMembers,
+    LeaderResponseDto leader
+) {
+
+    public static TeamDetailResponseDto of(final TeamInformationDto teamInformationDto,
+        final LeaderResponseDto leader,
+        final List<String> teamImageUrls) {
+        return new TeamDetailResponseDto(
+            teamInformationDto.getTeamId(),
+            teamInformationDto.getIsDeleted(),
+            teamInformationDto.getMemberNum(),
+            teamInformationDto.getRegion(),
+            teamInformationDto.getDrinkRate(),
+            teamInformationDto.getDrinkWithGame(),
+            teamInformationDto.getAdditionalActivity(),
+            teamInformationDto.getIntroduction(),
+            teamImageUrls,
+            teamInformationDto.getTeamMembers(),
+            leader
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "TeamDetailResponseDto{" +
+            "teamId=" + teamId +
+            ", isDeleted=" + isDeleted +
+            ", memberNum=" + memberNum +
+            ", region=" + region +
+            ", drinkRate=" + drinkRate +
+            ", drinkWithGame=" + drinkWithGame +
+            ", additionalActivity=" + additionalActivity +
+            ", introduction='" + introduction + '\'' +
+            ", teamImageUrls=" + teamImageUrls +
+            ", teamMembers=" + teamMembers +
+            ", leader=" + leader +
+            '}';
+    }
+}

--- a/src/main/java/com/e2i/wemeet/dto/response/team/TeamDetailResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/team/TeamDetailResponseDto.java
@@ -40,20 +40,4 @@ public record TeamDetailResponseDto(
         );
     }
 
-    @Override
-    public String toString() {
-        return "TeamDetailResponseDto{" +
-            "teamId=" + teamId +
-            ", isDeleted=" + isDeleted +
-            ", memberNum=" + memberNum +
-            ", region=" + region +
-            ", drinkRate=" + drinkRate +
-            ", drinkWithGame=" + drinkWithGame +
-            ", additionalActivity=" + additionalActivity +
-            ", introduction='" + introduction + '\'' +
-            ", teamImageUrls=" + teamImageUrls +
-            ", teamMembers=" + teamMembers +
-            ", leader=" + leader +
-            '}';
-    }
 }

--- a/src/main/java/com/e2i/wemeet/dto/response/team/TeamMemberResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/team/TeamMemberResponseDto.java
@@ -14,7 +14,7 @@ public record TeamMemberResponseDto(
 
     public static TeamMemberResponseDto of(TeamMember teamMember) {
         return TeamMemberResponseDto.builder()
-            .college(teamMember.getCollegeInfo().getCollegeCode().getCodeValue())
+            .college(teamMember.getCollegeName())
             .collegeType(teamMember.getCollegeInfo().getCollegeType().getDescription())
             .admissionYear(teamMember.getCollegeInfo().getAdmissionYear())
             .mbti(teamMember.getMbti())

--- a/src/main/java/com/e2i/wemeet/service/team/TeamService.java
+++ b/src/main/java/com/e2i/wemeet/service/team/TeamService.java
@@ -3,6 +3,7 @@ package com.e2i.wemeet.service.team;
 import com.e2i.wemeet.dto.request.team.CreateTeamRequestDto;
 import com.e2i.wemeet.dto.request.team.UpdateTeamRequestDto;
 import com.e2i.wemeet.dto.response.team.MyTeamDetailResponseDto;
+import com.e2i.wemeet.dto.response.team.TeamDetailResponseDto;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -25,6 +26,11 @@ public interface TeamService {
      */
     MyTeamDetailResponseDto readTeam(Long memberId);
 
+
+    /*
+     * 팀 상세 조회
+     */
+    TeamDetailResponseDto readByTeamId(Long teamId);
 
     /*
      * 팀 삭제

--- a/src/test/java/com/e2i/wemeet/controller/meeting/MeetingControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/meeting/MeetingControllerTest.java
@@ -18,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
+import com.e2i.wemeet.domain.member.data.CollegeType;
 import com.e2i.wemeet.domain.member.data.Mbti;
 import com.e2i.wemeet.domain.team.data.Region;
 import com.e2i.wemeet.dto.dsl.MeetingInformationDto;
@@ -362,12 +363,14 @@ class MeetingControllerTest extends AbstractControllerUnitTest {
                 LocalDateTime.now(), false, null, 1L, 2,
                 Region.HONGDAE, 1L,
                 "채원", Mbti.INFP,
-                "https://profile.com", "고려대학교");
+                "https://profile.com", "고려대학교",
+                CollegeType.ENGINEERING, "2022", true);
             final MeetingInformationDto meetingInformationDto2 = new MeetingInformationDto(2L,
                 LocalDateTime.now(), false, null, 2L, 2,
                 Region.HONGDAE, 2L,
                 "째림", Mbti.INFJ,
-                "https://profile.com", "서울대학교");
+                "https://profile.com", "서울대학교",
+                CollegeType.ARTS, "2019", true);
 
             List<AcceptedMeetingResponseDto> responseDtos = List.of(
                 AcceptedMeetingResponseDto.of(meetingInformationDto1,
@@ -400,6 +403,9 @@ class MeetingControllerTest extends AbstractControllerUnitTest {
                     jsonPath("$.data[0].leader.nickname").value("채원"),
                     jsonPath("$.data[0].leader.mbti").value(Mbti.INFP.name()),
                     jsonPath("$.data[0].leader.collegeName").value("고려대학교"),
+                    jsonPath("$.data[0].leader.collegeType").value(CollegeType.ENGINEERING.name()),
+                    jsonPath("$.data[0].leader.admissionYear").value("2022"),
+                    jsonPath("$.data[0].leader.imageAuth").value(true),
                     jsonPath("$.data[0].leader.leaderLowProfileImageUrl").value(
                         "https://profile.com"),
                     jsonPath("$.data[0].expired").value(false)
@@ -416,18 +422,18 @@ class MeetingControllerTest extends AbstractControllerUnitTest {
             // given
             final MeetingRequestInformationDto requestInformationDto1 = new MeetingRequestInformationDto(
                 1L, LocalDateTime.now(), "재미있게 놀아요!",
-                PENDING,
-                1L, 4,
+                PENDING, 1L, 4,
                 Region.HONGDAE, null, 1L,
                 "채원", Mbti.INFP,
-                "https://profile.com", "고려대학교");
+                "https://profile.com", "고려대학교",
+                CollegeType.ENGINEERING, "2022", true);
             final MeetingRequestInformationDto requestInformationDto2 = new MeetingRequestInformationDto(
                 2L, LocalDateTime.now(), "재미있게 놀아요!",
-                PENDING,
-                2L, 4,
+                PENDING, 2L, 4,
                 Region.HONGDAE, null, 2L,
                 "쨰림", Mbti.INFJ,
-                "https://profile.com", "서울대학교");
+                "https://profile.com", "서울대학교",
+                CollegeType.ARTS, "2019", true);
 
             List<SentMeetingResponseDto> sentMeetingResponseDtos = List.of(
                 SentMeetingResponseDto.of(requestInformationDto1, List.of("https://profile1.com")),
@@ -460,8 +466,10 @@ class MeetingControllerTest extends AbstractControllerUnitTest {
                     jsonPath("$.data[0].leader.nickname").value("채원"),
                     jsonPath("$.data[0].leader.mbti").value(Mbti.INFP.name()),
                     jsonPath("$.data[0].leader.collegeName").value("고려대학교"),
-                    jsonPath("$.data[0].leader.leaderLowProfileImageUrl").value(
-                        "https://profile.com")
+                    jsonPath("$.data[0].leader.leaderLowProfileImageUrl").value("https://profile.com"),
+                    jsonPath("$.data[0].leader.collegeType").value(CollegeType.ENGINEERING.name()),
+                    jsonPath("$.data[0].leader.admissionYear").value("2022"),
+                    jsonPath("$.data[0].leader.imageAuth").value(true)
                 );
             verify(meetingListService).getSentRequestList(anyLong(), any(LocalDateTime.class));
 
@@ -479,14 +487,16 @@ class MeetingControllerTest extends AbstractControllerUnitTest {
                 1L, 4,
                 Region.HONGDAE, null, 1L,
                 "채원", Mbti.INFP,
-                "https://profile.com", "고려대학교");
+                "https://profile.com", "고려대학교",
+                CollegeType.ENGINEERING, "2022", true);
             final MeetingRequestInformationDto requestInformationDto2 = new MeetingRequestInformationDto(
                 2L, LocalDateTime.now(), "재미있게 놀아요!",
                 PENDING,
                 2L, 4,
                 Region.HONGDAE, null, 2L,
                 "쨰림", Mbti.INFJ,
-                "https://profile.com", "서울대학교");
+                "https://profile.com", "서울대학교",
+                CollegeType.ARTS, "2019", true);
 
             List<ReceivedMeetingResponseDto> receivedMeetingResponseDtos = List.of(
                 ReceivedMeetingResponseDto.of(requestInformationDto1,
@@ -567,6 +577,12 @@ class MeetingControllerTest extends AbstractControllerUnitTest {
                                 .description("팀장 MBTI"),
                             fieldWithPath("data[].leader.collegeName").type(JsonFieldType.STRING)
                                 .description("팀장 대학교 이름"),
+                            fieldWithPath("data[].leader.collegeType").type(JsonFieldType.STRING)
+                                .description("팀장 학과"),
+                            fieldWithPath("data[].leader.admissionYear").type(JsonFieldType.STRING)
+                                .description("팀장 학번"),
+                            fieldWithPath("data[].leader.imageAuth").type(JsonFieldType.BOOLEAN)
+                                .description("팀장 프로필 인증 여부"),
                             fieldWithPath("data[].leader.leaderLowProfileImageUrl").type(
                                 JsonFieldType.STRING).description("팀장 저화질 프로필 이미지 URL"),
                             fieldWithPath("data[].expired").type(JsonFieldType.BOOLEAN)
@@ -619,6 +635,12 @@ class MeetingControllerTest extends AbstractControllerUnitTest {
                                 .description("팀장 대학교 이름"),
                             fieldWithPath("data[].leader.leaderLowProfileImageUrl").type(
                                 JsonFieldType.STRING).description("팀장 저화질 프로필 이미지 URL"),
+                            fieldWithPath("data[].leader.collegeType").type(JsonFieldType.STRING)
+                                .description("팀장 학과"),
+                            fieldWithPath("data[].leader.admissionYear").type(JsonFieldType.STRING)
+                                .description("팀장 학번"),
+                            fieldWithPath("data[].leader.imageAuth").type(JsonFieldType.BOOLEAN)
+                                .description("팀장 프로필 인증 여부"),
                             fieldWithPath("data[].pending").type(JsonFieldType.BOOLEAN)
                                 .description("미팅 신청 대기 여부"),
                             fieldWithPath("data[].deleted").type(JsonFieldType.BOOLEAN)

--- a/src/test/java/com/e2i/wemeet/domain/team/TeamCustomRepositoryImplTest.java
+++ b/src/test/java/com/e2i/wemeet/domain/team/TeamCustomRepositoryImplTest.java
@@ -1,0 +1,108 @@
+package com.e2i.wemeet.domain.team;
+
+import static com.e2i.wemeet.domain.member.data.Mbti.ENFJ;
+import static com.e2i.wemeet.domain.member.data.Mbti.ENFP;
+import static com.e2i.wemeet.domain.member.data.Mbti.ESFJ;
+import static com.e2i.wemeet.support.fixture.MemberFixture.KAI;
+import static com.e2i.wemeet.support.fixture.TeamFixture.HONGDAE_TEAM_1;
+import static com.e2i.wemeet.support.fixture.TeamImagesFixture.BASIC_TEAM_IMAGE;
+import static com.e2i.wemeet.support.fixture.TeamMemberFixture.create_3_man;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.e2i.wemeet.domain.member.Member;
+import com.e2i.wemeet.domain.member.MemberRepository;
+import com.e2i.wemeet.domain.team.data.TeamImageData;
+import com.e2i.wemeet.domain.team_image.TeamImageRepository;
+import com.e2i.wemeet.dto.dsl.TeamInformationDto;
+import com.e2i.wemeet.dto.response.LeaderResponseDto;
+import com.e2i.wemeet.exception.notfound.TeamNotFoundException;
+import com.e2i.wemeet.support.module.AbstractRepositoryUnitTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TeamCustomRepositoryImplTest extends AbstractRepositoryUnitTest {
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private TeamImageRepository teamImageRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("팀 ID로 팀 사진 url을 조회할 수 있다.")
+    @Test
+    void findTeamImagesByTeamId() {
+        //given
+        Member kai = memberRepository.save(KAI.create(ANYANG_CODE));
+        Team kaiTeam = teamRepository.save(HONGDAE_TEAM_1.create(kai, create_3_man()));
+        teamImageRepository.saveAll(BASIC_TEAM_IMAGE.createTeamImages(kaiTeam));
+
+        //when
+        List<TeamImageData> teamImageUrls = teamRepository.findTeamImagesByTeamId(kaiTeam.getTeamId());
+
+        //then
+        assertThat(teamImageUrls).hasSize(3)
+            .extracting(TeamImageData::url)
+            .containsAll(BASIC_TEAM_IMAGE.getTeamImages());
+    }
+
+    @DisplayName("팀 사진이 등록되지 않았다면 아무것도 조회되지 않는다.")
+    @Test
+    void findTeamImagesByTeamIdWithoutTeamImages() {
+        //given
+        Member kai = memberRepository.save(KAI.create(ANYANG_CODE));
+        Team kaiTeam = teamRepository.save(HONGDAE_TEAM_1.create(kai, create_3_man()));
+
+        //when
+        List<TeamImageData> teamImageUrls = teamRepository.findTeamImagesByTeamId(kaiTeam.getTeamId());
+
+        //then
+        assertThat(teamImageUrls).isEmpty();
+    }
+
+    @DisplayName("팀 ID로 팀 리더 정보를 조회할 수 있다.")
+    @Test
+    void findLeaderByTeamId() {
+        //given
+        Member kai = memberRepository.save(KAI.create(ANYANG_CODE));
+        Team kaiTeam = teamRepository.save(HONGDAE_TEAM_1.create(kai, create_3_man()));
+
+        //when
+        LeaderResponseDto leader = teamRepository.findLeaderByTeamId(kaiTeam.getTeamId())
+            .orElseThrow(TeamNotFoundException::new);
+
+        //then
+        assertThat(leader)
+            .extracting("leaderId", "nickname", "collegeName", "leaderLowProfileImageUrl")
+            .contains(kai.getMemberId(), kai.getNickname(), kai.getCollegeName(), kai.getProfileImage().getLowUrl());
+    }
+
+    @DisplayName("팀 ID로 팀 정보를 조회할 수 있다.")
+    @Test
+    void findTeamInformationByTeamId() {
+        //given
+        Member kai = memberRepository.save(KAI.create(ANYANG_CODE));
+        Team kaiTeam = teamRepository.save(HONGDAE_TEAM_1.create(kai, create_3_man()));
+
+        //when
+        TeamInformationDto teamInformation = teamRepository.findTeamInformationByTeamId(kaiTeam.getTeamId())
+            .orElseThrow(TeamNotFoundException::new);
+
+        //then
+        assertThat(teamInformation)
+            .extracting("teamId", "memberNum", "region", "isDeleted")
+            .contains(kaiTeam.getTeamId(), kaiTeam.getMemberNum(), kaiTeam.getRegion(), kaiTeam.isDeleted());
+        assertThat(teamInformation.getTeamMembers()).hasSize(3)
+            .extracting("college", "collegeType", "admissionYear", "mbti")
+            .contains(
+                tuple("고려대", "ENGINEERING", "18", ENFJ),
+                tuple("고려대", "ENGINEERING", "18", ENFP),
+                tuple("인하대", "ENGINEERING", "22", ESFJ)
+            );
+    }
+}

--- a/src/test/java/com/e2i/wemeet/service/team/TeamServiceImplTest.java
+++ b/src/test/java/com/e2i/wemeet/service/team/TeamServiceImplTest.java
@@ -1,0 +1,78 @@
+package com.e2i.wemeet.service.team;
+
+import static com.e2i.wemeet.support.fixture.MemberFixture.KAI;
+import static com.e2i.wemeet.support.fixture.TeamFixture.HONGDAE_TEAM_1;
+import static com.e2i.wemeet.support.fixture.TeamImagesFixture.BASIC_TEAM_IMAGE;
+import static com.e2i.wemeet.support.fixture.TeamMemberFixture.create_3_man;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.e2i.wemeet.domain.member.Member;
+import com.e2i.wemeet.domain.member.MemberRepository;
+import com.e2i.wemeet.domain.member.data.CollegeType;
+import com.e2i.wemeet.domain.member.data.Mbti;
+import com.e2i.wemeet.domain.team.Team;
+import com.e2i.wemeet.domain.team.TeamRepository;
+import com.e2i.wemeet.domain.team.data.AdditionalActivity;
+import com.e2i.wemeet.domain.team.data.DrinkRate;
+import com.e2i.wemeet.domain.team.data.DrinkWithGame;
+import com.e2i.wemeet.domain.team.data.Region;
+import com.e2i.wemeet.domain.team_image.TeamImageRepository;
+import com.e2i.wemeet.dto.response.team.TeamDetailResponseDto;
+import com.e2i.wemeet.support.module.AbstractServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TeamServiceImplTest extends AbstractServiceTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private TeamImageRepository teamImageRepository;
+
+    @Autowired
+    private TeamService teamService;
+
+    @DisplayName("TeamID로 Team 정보를 조회할 수 있다.")
+    @Test
+    void readByTeamId() {
+        // given
+        Member kai = memberRepository.save(KAI.create(ANYANG_CODE));
+        Team kaiTeam = teamRepository.save(HONGDAE_TEAM_1.create(kai, create_3_man()));
+        teamImageRepository.saveAll(BASIC_TEAM_IMAGE.createTeamImages(kaiTeam));
+
+        // when
+        TeamDetailResponseDto responseDto = teamService.readByTeamId(kaiTeam.getTeamId());
+
+        System.out.println("responseDto = " + responseDto);
+
+        // then
+        assertThat(responseDto)
+            .extracting(
+                "isDeleted", "memberNum", "region", "drinkRate",
+                "drinkWithGame", "additionalActivity", "introduction")
+            .contains(false, 4, Region.HONGDAE, DrinkRate.LOW,
+                DrinkWithGame.ANY, AdditionalActivity.CAFE, HONGDAE_TEAM_1.getIntroduction());
+        assertThat(responseDto.teamImageUrls())
+            .hasSize(3)
+            .containsAll(BASIC_TEAM_IMAGE.getTeamImages());
+        assertThat(responseDto.teamMembers())
+            .hasSize(3)
+            .extracting("college", "collegeType", "admissionYear", "mbti")
+            .containsExactly(
+                tuple("고려대", CollegeType.ENGINEERING.name(), "18", Mbti.ENFJ),
+                tuple("고려대", CollegeType.ENGINEERING.name(), "18", Mbti.ENFP),
+                tuple("인하대", CollegeType.ENGINEERING.name(), "22", Mbti.ESFJ)
+            );
+        assertThat(responseDto.leader())
+            .extracting("leaderId", "nickname", "collegeName",
+                "collegeType", "leaderLowProfileImageUrl")
+            .contains(kai.getMemberId(), kai.getNickname(), kai.getCollegeName(),
+                kai.getCollegeInfo().getCollegeType(), kai.getProfileImage().getLowUrl());
+    }
+}

--- a/src/test/java/com/e2i/wemeet/support/fixture/TeamFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/TeamFixture.java
@@ -1,5 +1,7 @@
 package com.e2i.wemeet.support.fixture;
 
+import static com.e2i.wemeet.support.config.ReflectionUtils.setFieldValue;
+
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.team.Team;
 import com.e2i.wemeet.domain.team.data.AdditionalActivity;
@@ -12,7 +14,6 @@ import com.e2i.wemeet.dto.request.team.CreateTeamRequestDto;
 import com.e2i.wemeet.dto.request.team.TeamMemberRequestDto;
 import com.e2i.wemeet.dto.request.team.UpdateTeamRequestDto;
 import com.e2i.wemeet.dto.response.team.MyTeamDetailResponseDto;
-import java.lang.reflect.Field;
 import java.util.List;
 
 public enum TeamFixture {
@@ -49,6 +50,14 @@ public enum TeamFixture {
         Team team = createBuilder(teamLeader)
             .build();
         team.addTeamMembers(teamMembers);
+        return team;
+    }
+
+    public Team create_with_id(Member teamLeader, List<TeamMember> teamMembers, Long teamId) {
+        Team team = createBuilder(teamLeader)
+            .build();
+        team.addTeamMembers(teamMembers);
+        setFieldValue(team, "teamId", teamId);
         return team;
     }
 
@@ -130,17 +139,6 @@ public enum TeamFixture {
             .additionalActivity(this.additionalActivity)
             .introduction(this.introduction)
             .chatLink(this.chatLink);
-    }
-
-    private void setTeamId(Team team, Long teamId) {
-        Field field;
-        try {
-            field = team.getClass().getDeclaredField("teamId");
-            field.setAccessible(true);
-            field.set(team, teamId);
-        } catch (IllegalAccessException | NoSuchFieldException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     public Integer getMemberNum() {


### PR DESCRIPTION
## Related Issue
#110 
## Description
- teamId로 Team의 상세정보를 조회할 수 있는 API를 추가합니다.

## Checklist:
- [x] add query
- [x] service & controller
- [x] Test