### PR TITLE
refactor(team): add some fields to find team detail query response

### DIFF
--- a/src/main/java/com/e2i/wemeet/domain/team/TeamCustomRepositoryImpl.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/TeamCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.e2i.wemeet.domain.team;
 
 import static com.e2i.wemeet.domain.code.QCode.code;
 import static com.e2i.wemeet.domain.heart.QHeart.heart;
+import static com.e2i.wemeet.domain.meeting.QMeetingRequest.meetingRequest;
 import static com.e2i.wemeet.domain.member.QMember.member;
 import static com.e2i.wemeet.domain.team.QTeam.team;
 import static com.e2i.wemeet.domain.team_image.QTeamImage.teamImage;
@@ -71,13 +72,19 @@ public class TeamCustomRepositoryImpl implements TeamCustomRepository {
                     team.additionalActivity,
                     team.introduction,
                     team.deletedAt,
-                    heart.heartId
+                    meetingRequest.acceptStatus,
+                    heart.heartId,
+                    myTeam.teamId
                 ))
                 .from(team)
                 .leftJoin(myTeam).on(myTeam.teamLeader.memberId.eq(memberLeaderId))
                 .leftJoin(heart).on(
                     heart.team.eq(myTeam),
                     heart.partnerTeam.teamId.eq(teamId)
+                )
+                .leftJoin(meetingRequest).on(
+                    meetingRequest.team.eq(myTeam),
+                    meetingRequest.partnerTeam.teamId.eq(teamId)
                 )
                 .where(team.teamId.eq(teamId))
                 .fetchOne())

--- a/src/main/java/com/e2i/wemeet/dto/dsl/TeamInformationDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/dsl/TeamInformationDto.java
@@ -1,5 +1,6 @@
 package com.e2i.wemeet.dto.dsl;
 
+import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
 import com.e2i.wemeet.domain.team.Team;
 import com.e2i.wemeet.domain.team.data.AdditionalActivity;
 import com.e2i.wemeet.domain.team.data.DrinkRate;
@@ -24,12 +25,14 @@ public class TeamInformationDto {
     private final AdditionalActivity additionalActivity;
     private final String introduction;
     private final Boolean isDeleted;
+    private final AcceptStatus meetingRequestStatus;
     private final Boolean isLiked;
+    private final Boolean memberHasTeam;
 
     @Builder
     public TeamInformationDto(Long teamId, Integer memberNum, Region region, DrinkRate drinkRate,
         DrinkWithGame drinkWithGame, AdditionalActivity additionalActivity, String introduction,
-        LocalDateTime deletedAt, Long heartId) {
+        LocalDateTime deletedAt, AcceptStatus meetingRequestStatus, Long heartId, Long requestMemberTeamId) {
         this.teamId = teamId;
         this.memberNum = memberNum;
         this.region = region;
@@ -38,7 +41,9 @@ public class TeamInformationDto {
         this.additionalActivity = additionalActivity;
         this.introduction = introduction;
         this.isDeleted = deletedAt != null;
+        this.meetingRequestStatus = meetingRequestStatus;
         this.isLiked = heartId != null;
+        this.memberHasTeam = requestMemberTeamId != null;
     }
 
     public static TeamInformationDto of(Team team) {
@@ -52,6 +57,8 @@ public class TeamInformationDto {
             .additionalActivity(team.getAdditionalActivity())
             .introduction(team.getIntroduction())
             .deletedAt(team.getDeletedAt())
+            .meetingRequestStatus(AcceptStatus.PENDING)
+            .requestMemberTeamId(1L)
             .build();
 
         dto.setTeamMember(team.getTeamMembers());
@@ -68,5 +75,23 @@ public class TeamInformationDto {
         this.teamMembers = teamMembers.stream()
             .map(TeamMemberResponseDto::of)
             .toList();
+    }
+
+    @Override
+    public String toString() {
+        return "TeamInformationDto{" +
+            "teamId=" + teamId +
+            ", teamMembers=" + teamMembers +
+            ", memberNum=" + memberNum +
+            ", region=" + region +
+            ", drinkRate=" + drinkRate +
+            ", drinkWithGame=" + drinkWithGame +
+            ", additionalActivity=" + additionalActivity +
+            ", introduction='" + introduction + '\'' +
+            ", isDeleted=" + isDeleted +
+            ", meetingRequestStatus=" + meetingRequestStatus +
+            ", isLiked=" + isLiked +
+            ", memberHasTeam=" + memberHasTeam +
+            '}';
     }
 }

--- a/src/main/java/com/e2i/wemeet/dto/response/team/TeamDetailResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/team/TeamDetailResponseDto.java
@@ -1,5 +1,6 @@
 package com.e2i.wemeet.dto.response.team;
 
+import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
 import com.e2i.wemeet.domain.team.data.AdditionalActivity;
 import com.e2i.wemeet.domain.team.data.DrinkRate;
 import com.e2i.wemeet.domain.team.data.DrinkWithGame;
@@ -12,6 +13,8 @@ public record TeamDetailResponseDto(
     Long teamId,
     Boolean isDeleted,
     Boolean isLiked,
+    AcceptStatus meetingRequestStatus,
+    Boolean memberHasTeam,
     Integer memberNum,
     Region region,
     DrinkRate drinkRate,
@@ -30,6 +33,8 @@ public record TeamDetailResponseDto(
             teamInformationDto.getTeamId(),
             teamInformationDto.getIsDeleted(),
             teamInformationDto.getIsLiked(),
+            teamInformationDto.getMeetingRequestStatus(),
+            teamInformationDto.getMemberHasTeam(),
             teamInformationDto.getMemberNum(),
             teamInformationDto.getRegion(),
             teamInformationDto.getDrinkRate(),

--- a/src/main/resources/static/swagger-ui/openapi3.yaml
+++ b/src/main/resources/static/swagger-ui/openapi3.yaml
@@ -702,14 +702,15 @@ paths:
           content:
             application/json;charset=UTF-8:
               schema:
-                $ref: '#/components/schemas/v1-team-teamId1852923051'
+                $ref: '#/components/schemas/v1-team-teamDetailResponse'
               examples:
                 팀 상세 정보 조회:
                   value: "{\"status\":\"SUCCESS\",\"message\":\"Get Team Detail Success\"\
-                    ,\"data\":{\"teamId\":1,\"isDeleted\":false,\"isLiked\":true,\"memberNum\":4,\"\
-                    region\":\"HONGDAE\",\"drinkRate\":\"LOW\",\"drinkWithGame\":\"\
-                    ANY\",\"additionalActivity\":\"CAFE\",\"introduction\":\"안녕하세요\
-                    ! 반가워요! 홍대팀 1입니다!!\",\"teamImageUrls\":[\"/v1/test1\",\"/v1/test2\"\
+                    ,\"data\":{\"teamId\":1,\"isDeleted\":false,\"isLiked\":true,\"\
+                    meetingRequestStatus\":\"PENDING\",\"memberHasTeam\":true,\"memberNum\"\
+                    :4,\"region\":\"HONGDAE\",\"drinkRate\":\"LOW\",\"drinkWithGame\"\
+                    :\"ANY\",\"additionalActivity\":\"CAFE\",\"introduction\":\"안녕\
+                    하세요! 반가워요! 홍대팀 1입니다!!\",\"teamImageUrls\":[\"/v1/test1\",\"/v1/test2\"\
                     ,\"/v1/test3\"],\"teamMembers\":[{\"college\":\"고려대\",\"collegeType\"\
                     :\"자연공학\",\"admissionYear\":\"18\",\"mbti\":\"ENFJ\"},{\"college\"\
                     :\"고려대\",\"collegeType\":\"자연공학\",\"admissionYear\":\"18\",\"\
@@ -1272,6 +1273,110 @@ components:
               profileImageURL:
                 type: string
                 description: 추천 팀 팀장 프로필 이미지
+        message:
+          type: string
+          description: 응답 메시지
+        status:
+          type: string
+          description: 응답 상태
+    v1-team-teamDetailResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            leader:
+              type: object
+              properties:
+                collegeName:
+                  type: string
+                  description: 팀장 대학교
+                leaderLowProfileImageUrl:
+                  type: string
+                  description: 팀장 프로필 사진
+                collegeType:
+                  type: string
+                  description: 팀장 학과
+                admissionYear:
+                  type: string
+                  description: 팀장 학번
+                nickname:
+                  type: string
+                  description: 팀장 닉네임
+                mbti:
+                  type: string
+                  description: 팀장 MBTI
+                imageAuth:
+                  type: boolean
+                  description: 팀장 프로필 사진 인증 여부
+                leaderId:
+                  type: number
+                  description: 팀장 ID
+            isLiked:
+              type: boolean
+              description: 팀 좋아요 여부
+            additionalActivity:
+              type: string
+              description: 취미 및 관심사
+            teamMembers:
+              type: array
+              items:
+                type: object
+                properties:
+                  college:
+                    type: string
+                    description: 대학교 명
+                  collegeType:
+                    type: string
+                    description: 학과
+                  admissionYear:
+                    type: string
+                    description: 학번
+                  mbti:
+                    type: string
+                    description: MBTI
+            memberNum:
+              type: number
+              description: 팀 인원수
+            drinkWithGame:
+              type: string
+              description: 술게임 여부
+            isDeleted:
+              type: boolean
+              description: 팀 삭제 여부
+            drinkRate:
+              type: string
+              description: 음주 수치
+            teamId:
+              type: number
+              description: 팀 ID
+            memberHasTeam:
+              type: boolean
+              description: 요청을 한 유저가 팀에 속해있는지 여부를 반환합니다.
+            meetingRequestStatus:
+              type: string
+              description: |2
+                    미팅 요청 상태
+                    ACCEPT (미팅 성사됨),
+                    PENDING (요청 대기중),
+                    REJECT (요청 거절당함),
+                    EXPIRED (요청 만료됨),
+                    null (요청 내역 없음) 중 하나
+            region:
+              type: string
+              description: 선호 지역
+            introduction:
+              type: string
+              description: 팀 소개
+            teamImageUrls:
+              type: array
+              description: 팀 사진 URL
+              items:
+                oneOf:
+                  - type: object
+                  - type: boolean
+                  - type: string
+                  - type: number
         message:
           type: string
           description: 응답 메시지

--- a/src/test/java/com/e2i/wemeet/controller/team/TeamControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/team/TeamControllerTest.java
@@ -210,6 +210,8 @@ class TeamControllerTest extends AbstractControllerUnitTest {
                 jsonPath("$.data.teamId").value(1L),
                 jsonPath("$.data.isDeleted").value(false),
                 jsonPath("$.data.isLiked").value(true),
+                jsonPath("$.data.meetingRequestStatus").value("PENDING"),
+                jsonPath("$.data.memberHasTeam").value(true),
                 jsonPath("$.data.memberNum").value(4),
                 jsonPath("$.data.region").value("HONGDAE"),
                 jsonPath("$.data.drinkRate").value("LOW"),
@@ -473,6 +475,18 @@ class TeamControllerTest extends AbstractControllerUnitTest {
                             .description("팀 삭제 여부"),
                         fieldWithPath("data.isLiked").type(JsonFieldType.BOOLEAN)
                             .description("팀 좋아요 여부"),
+                        fieldWithPath("data.meetingRequestStatus").type(JsonFieldType.STRING)
+                            .description(
+                                """
+                                        미팅 요청 상태
+                                        ACCEPT (미팅 성사됨),
+                                        PENDING (요청 대기중),
+                                        REJECT (요청 거절당함),
+                                        EXPIRED (요청 만료됨),
+                                        null (요청 내역 없음) 중 하나
+                                    """),
+                        fieldWithPath("data.memberHasTeam").type(JsonFieldType.BOOLEAN)
+                            .description("요청을 한 유저가 팀에 속해있는지 여부를 반환합니다."),
                         fieldWithPath("data.memberNum").type(JsonFieldType.NUMBER)
                             .description("팀 인원수"),
                         fieldWithPath("data.region").type(JsonFieldType.STRING)


### PR DESCRIPTION
## Related Issue

## Description
- 팀 상세정보 조회 API의 응답 결과로 memberHasTeam: Boolean (요청자의 팀 존재여부)과 meetingRequestStatus: AcceptStatus (미팅 요청 상태)를 추가합니다.
  - meetingRequestStatus == null은 해당 팀에게 미팅 신청을 하지 않았음을 나타냅니다.

