### PR TITLE
refactor(meeting): Change meeting subscriptions to prevent duplicate

### DIFF
--- a/src/main/java/com/e2i/wemeet/domain/meeting/MeetingRepository.java
+++ b/src/main/java/com/e2i/wemeet/domain/meeting/MeetingRepository.java
@@ -1,5 +1,6 @@
 package com.e2i.wemeet.domain.meeting;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -30,5 +31,17 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long>, Meeting
         where t.teamId = :teamId
         """)
     String findLeaderPhoneNumberById(@Param("teamId") final Long teamId);
+
+    /*
+     * 미팅이 이미 존재하는지 조회
+     * */
+    @Query("""
+        select mt.createdAt from Meeting mt
+        join mt.partnerTeam pt
+        join mt.team t
+        join MeetingRequest mr on mr.partnerTeam = pt and mr.team = t
+        where mr.meetingRequestId = :meetingRequestId
+        """)
+    List<LocalDateTime> findCreatedAtByMeetingRequestId(@Param("meetingRequestId") final Long meetingRequestId);
 
 }

--- a/src/main/java/com/e2i/wemeet/domain/meeting/MeetingRequestRepository.java
+++ b/src/main/java/com/e2i/wemeet/domain/meeting/MeetingRequestRepository.java
@@ -1,6 +1,9 @@
 package com.e2i.wemeet.domain.meeting;
 
+import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
+import com.e2i.wemeet.domain.team.Team;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -18,5 +21,20 @@ public interface MeetingRequestRepository extends JpaRepository<MeetingRequest, 
     @Modifying(clearAutomatically = true)
     @Query("update MeetingRequest mr set mr.acceptStatus = 3 where mr.meetingRequestId in :meetingRequestIdList")
     void updateRequestToExpired(@Param("meetingRequestIdList") Collection<Long> meetingRequestIdList);
+
+    // 미팅 신청 이력 조회 ('대기중' 인 요청만)
+    @Query("""
+        select mr.meetingRequestId from MeetingRequest mr
+        where mr.team.teamId = :teamId and mr.partnerTeam.teamId = :partnerTeamId 
+        and mr.acceptStatus = 0
+        """)
+    Optional<Long> findIdByTeamIdAndPartnerTeamId(@Param("teamId") Long teamId, @Param("partnerTeamId") Long partnerTeamId);
+
+    // 팀의 이전 미팅 신청 이력 조회 (신청 상태 조건)
+    @Query("""
+        select mr from MeetingRequest mr
+        where mr.team = :team and mr.acceptStatus = :acceptStatus
+        """)
+    List<MeetingRequest> findAllByTeamAndAcceptStatus(@Param("team") Team team, @Param("acceptStatus") AcceptStatus acceptStatus);
 
 }

--- a/src/main/java/com/e2i/wemeet/exception/ErrorCode.java
+++ b/src/main/java/com/e2i/wemeet/exception/ErrorCode.java
@@ -47,6 +47,8 @@ public enum ErrorCode {
     INVALID_CHAT_LINK_FORMAT(40033, "invalid.chat.link.format"),
     ACCEPT_STATUS_IS_NOT_PENDING(40034, "accept.status.is.not.pending"),
     SUGGESTION_HISTORY_EXISTS(40035, "suggestion.history.exists"),
+    DUPLICATE_MEETING_REQUEST(40041, "duplicate.meeting.request"),
+    MEETING_ALREADY_EXIST(40042, "meeting.already.exist"),
 
     NOTFOUND_SMS_CREDENTIAL(40100, "notfound.sms.credential"),
     MEMBER_NOT_FOUND(40101, "member.not.found"),

--- a/src/main/java/com/e2i/wemeet/exception/badrequest/DuplicateMeetingRequestException.java
+++ b/src/main/java/com/e2i/wemeet/exception/badrequest/DuplicateMeetingRequestException.java
@@ -1,0 +1,11 @@
+package com.e2i.wemeet.exception.badrequest;
+
+import com.e2i.wemeet.exception.ErrorCode;
+
+public class DuplicateMeetingRequestException extends BadRequestException {
+
+    public DuplicateMeetingRequestException() {
+        super(ErrorCode.DUPLICATE_MEETING_REQUEST);
+    }
+
+}

--- a/src/main/java/com/e2i/wemeet/exception/badrequest/MeetingAlreadyExistException.java
+++ b/src/main/java/com/e2i/wemeet/exception/badrequest/MeetingAlreadyExistException.java
@@ -1,0 +1,11 @@
+package com.e2i.wemeet.exception.badrequest;
+
+import com.e2i.wemeet.exception.ErrorCode;
+
+public class MeetingAlreadyExistException extends BadRequestException {
+
+    public MeetingAlreadyExistException() {
+        super(ErrorCode.MEETING_ALREADY_EXIST);
+    }
+
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -109,3 +109,6 @@ heart.already.exists=이미 오늘의 좋아요를 모두 소진하였습니다.
 not.send.to.own.team=본인 팀에게는 좋아요를 보낼 수 없습니다.
 team.not.exists=팀이 존재하지 않습니다.
 not.equal.role.to.token=토큰에 담긴 권한과 실제 권한이 다릅니다.
+# Duplicate
+duplicate.meeting.request=해당 팀에게 보낸 미팅 요청이 이미 존재합니다.
+meeting.already.exist=성사된 미팅이 이미 존재합니다.

--- a/src/test/java/com/e2i/wemeet/domain/meeting/MeetingRepositoryTest.java
+++ b/src/test/java/com/e2i/wemeet/domain/meeting/MeetingRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.e2i.wemeet.domain.meeting;
 
 import static com.e2i.wemeet.support.fixture.MeetingFixture.BASIC_MEETING;
+import static com.e2i.wemeet.support.fixture.MeetingRequestFixture.WITH_OUT_MESSAGE;
 import static com.e2i.wemeet.support.fixture.MemberFixture.CHAEWON;
 import static com.e2i.wemeet.support.fixture.MemberFixture.KAI;
 import static com.e2i.wemeet.support.fixture.MemberFixture.RIM;
@@ -14,6 +15,7 @@ import com.e2i.wemeet.domain.member.MemberRepository;
 import com.e2i.wemeet.domain.team.Team;
 import com.e2i.wemeet.domain.team.TeamRepository;
 import com.e2i.wemeet.support.module.AbstractRepositoryUnitTest;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +31,9 @@ class MeetingRepositoryTest extends AbstractRepositoryUnitTest {
 
     @Autowired
     private MeetingRepository meetingRepository;
+
+    @Autowired
+    private MeetingRequestRepository meetingRequestRepository;
 
     @DisplayName("미팅 상태를 '종료'로 변경할 수 있다.")
     @Test
@@ -74,4 +79,50 @@ class MeetingRepositoryTest extends AbstractRepositoryUnitTest {
         // then
         assertThat(leaderPhoneNumber).isEqualTo(KAI.getPhoneNumber());
     }
+
+    @DisplayName("미팅 요청 정보를 통해 이전 미팅 성사 내역을 조회할 수 있다")
+    @Test
+    void findIdByLeaderIdAndMeetingRequestId() {
+        // given
+        Member kai = memberRepository.save(KAI.create(ANYANG_CODE));
+        Member rim = memberRepository.save(RIM.create(WOMANS_CODE));
+        Team kaiTeam = teamRepository.save(HONGDAE_TEAM_1.create(kai, create_3_man()));
+        Team rimTeam = teamRepository.save(HONGDAE_TEAM_1.create(rim, create_3_woman()));
+
+        meetingRequestRepository.save(WITH_OUT_MESSAGE.create(kaiTeam, rimTeam)).getMeetingRequestId();
+        Meeting meeting = meetingRepository.save(BASIC_MEETING.create(kaiTeam, rimTeam));
+        Long meetingRequestId2 = meetingRequestRepository.save(WITH_OUT_MESSAGE.create(kaiTeam, rimTeam)).getMeetingRequestId();
+        Meeting meeting2 = meetingRepository.save(BASIC_MEETING.create(kaiTeam, rimTeam));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<LocalDateTime> findMeetingCreatedAt = meetingRepository.findCreatedAtByMeetingRequestId(meetingRequestId2);
+
+        // then
+        assertThat(findMeetingCreatedAt).hasSize(2)
+            .containsExactlyInAnyOrder(meeting.getCreatedAt(), meeting2.getCreatedAt());
+    }
+
+    @DisplayName("미팅 성사 내역이 없다면 이전 미팅 성사 내역을 조회할 수 없다.")
+    @Test
+    void findIdByLeaderIdAndMeetingRequestIdWithoutMeeting() {
+        // given
+        Member kai = memberRepository.save(KAI.create(ANYANG_CODE));
+        Member rim = memberRepository.save(RIM.create(WOMANS_CODE));
+        Team kaiTeam = teamRepository.save(HONGDAE_TEAM_1.create(kai, create_3_man()));
+        Team rimTeam = teamRepository.save(HONGDAE_TEAM_1.create(rim, create_3_woman()));
+
+        meetingRequestRepository.save(WITH_OUT_MESSAGE.create(kaiTeam, rimTeam)).getMeetingRequestId();
+        Long meetingRequestId2 = meetingRequestRepository.save(WITH_OUT_MESSAGE.create(kaiTeam, rimTeam)).getMeetingRequestId();
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<LocalDateTime> findMeetingCreatedAt = meetingRepository.findCreatedAtByMeetingRequestId(meetingRequestId2);
+
+        // then
+        assertThat(findMeetingCreatedAt).isEmpty();
+    }
+
 }

--- a/src/test/java/com/e2i/wemeet/domain/meeting/MeetingRequestRepositoryTest.java
+++ b/src/test/java/com/e2i/wemeet/domain/meeting/MeetingRequestRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.e2i.wemeet.domain.meeting;
 
+import static com.e2i.wemeet.domain.meeting.data.AcceptStatus.ACCEPT;
 import static com.e2i.wemeet.domain.meeting.data.AcceptStatus.EXPIRED;
+import static com.e2i.wemeet.domain.meeting.data.AcceptStatus.REJECT;
 import static com.e2i.wemeet.support.fixture.MeetingRequestFixture.BASIC_REQUEST;
 import static com.e2i.wemeet.support.fixture.MeetingRequestFixture.WITH_OUT_MESSAGE;
 import static com.e2i.wemeet.support.fixture.MemberFixture.CHAEWON;
@@ -9,16 +11,20 @@ import static com.e2i.wemeet.support.fixture.MemberFixture.RIM;
 import static com.e2i.wemeet.support.fixture.TeamFixture.HONGDAE_TEAM_1;
 import static com.e2i.wemeet.support.fixture.TeamMemberFixture.create_3_man;
 import static com.e2i.wemeet.support.fixture.TeamMemberFixture.create_3_woman;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.e2i.wemeet.domain.meeting.data.AcceptStatus;
 import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.MemberRepository;
 import com.e2i.wemeet.domain.team.Team;
 import com.e2i.wemeet.domain.team.TeamRepository;
 import com.e2i.wemeet.support.module.AbstractRepositoryUnitTest;
 import java.util.List;
-import org.assertj.core.api.Assertions;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class MeetingRequestRepositoryTest extends AbstractRepositoryUnitTest {
@@ -54,8 +60,90 @@ class MeetingRequestRepositoryTest extends AbstractRepositoryUnitTest {
 
         // then
         List<MeetingRequest> findMeetingRequest = meetingRequestRepository.findAllById(list);
-        Assertions.assertThat(findMeetingRequest).hasSize(2)
+        assertThat(findMeetingRequest).hasSize(2)
             .extracting("acceptStatus")
             .containsOnly(EXPIRED);
+    }
+
+    @DisplayName("미팅 신청이 이미 존재하는지 확인할 수 있다.")
+    @Test
+    void findMeetingRequestByTeamAndPartnerTeamId() {
+        // given
+        Member kai = memberRepository.save(KAI.create(ANYANG_CODE));
+        Member rim = memberRepository.save(RIM.create(WOMANS_CODE));
+        Team kaiTeam = teamRepository.save(HONGDAE_TEAM_1.create(kai, create_3_man()));
+        Team rimTeam = teamRepository.save(HONGDAE_TEAM_1.create(rim, create_3_woman()));
+
+        meetingRequestRepository.save(WITH_OUT_MESSAGE.create(kaiTeam, rimTeam));
+
+        // when
+        Optional<Long> findId = meetingRequestRepository.findIdByTeamIdAndPartnerTeamId(kaiTeam.getTeamId(), rimTeam.getTeamId());
+
+        // then
+        assertThat(findId).isPresent();
+    }
+
+    @DisplayName("미팅을 신청하지 않았다면 아무것도 조회되지 않는다.")
+    @Test
+    void findMeetingRequestByTeamAndPartnerTeamIdWithoutRequest() {
+        // given
+        Member kai = memberRepository.save(KAI.create(ANYANG_CODE));
+        Member rim = memberRepository.save(RIM.create(WOMANS_CODE));
+
+        Team kaiTeam = teamRepository.save(HONGDAE_TEAM_1.create(kai, create_3_man()));
+        Team rimTeam = teamRepository.save(HONGDAE_TEAM_1.create(rim, create_3_woman()));
+
+        // when
+        Optional<Long> findId = meetingRequestRepository.findIdByTeamIdAndPartnerTeamId(kaiTeam.getTeamId(), rimTeam.getTeamId());
+
+        // then
+        assertThat(findId).isEmpty();
+    }
+
+    @DisplayName("이전에 미팅을 신청했던 팀이더라도, 해당 요청이 현재 '대기중' 상태가 아니라면 아무것도 조회되지 않는다.")
+    @Test
+    void findMeetingRequestByTeamAndPartnerTeamIdBeforeRequestExpired() {
+        // given
+        Member kai = memberRepository.save(KAI.create(ANYANG_CODE));
+        Member rim = memberRepository.save(RIM.create(WOMANS_CODE));
+
+        Team kaiTeam = teamRepository.save(HONGDAE_TEAM_1.create(kai, create_3_man()));
+        Team rimTeam = teamRepository.save(HONGDAE_TEAM_1.create(rim, create_3_woman()));
+
+        MeetingRequest meetingRequest = WITH_OUT_MESSAGE.create(kaiTeam, rimTeam);
+        meetingRequest.changeStatus(REJECT);
+        meetingRequestRepository.save(meetingRequest);
+
+        // when
+        Optional<Long> findId = meetingRequestRepository.findIdByTeamIdAndPartnerTeamId(kaiTeam.getTeamId(), rimTeam.getTeamId());
+
+        // then
+        assertThat(findId).isEmpty();
+    }
+
+    @DisplayName("팀의 미팅 신청 목록을 조회할 수 있다.")
+    @CsvSource({"ACCEPT, 1", "PENDING, 1", "REJECT, 0", "EXPIRED, 0"})
+    @ParameterizedTest
+    void findAllByTeamAndAcceptStatus(final AcceptStatus status, final int expectedSize) {
+        // given
+        Member kai = memberRepository.save(KAI.create(ANYANG_CODE));
+        Member rim = memberRepository.save(RIM.create(WOMANS_CODE));
+        Member chaewon = memberRepository.save(CHAEWON.create(WOMANS_CODE));
+
+        Team kaiTeam = teamRepository.save(HONGDAE_TEAM_1.create(kai, create_3_man()));
+        Team rimTeam = teamRepository.save(HONGDAE_TEAM_1.create(rim, create_3_woman()));
+        Team chaewonTeam = teamRepository.save(HONGDAE_TEAM_1.create(chaewon, create_3_woman()));
+
+        MeetingRequest meetingRequestAccept = WITH_OUT_MESSAGE.create(kaiTeam, rimTeam);
+        meetingRequestAccept.changeStatus(ACCEPT);
+        MeetingRequest meetingRequestPending = BASIC_REQUEST.create(kaiTeam, chaewonTeam);
+
+        meetingRequestRepository.saveAll(List.of(meetingRequestAccept, meetingRequestPending));
+
+        // when
+        List<MeetingRequest> findMeetingRequest = meetingRequestRepository.findAllByTeamAndAcceptStatus(kaiTeam, status);
+
+        // then
+        assertThat(findMeetingRequest).hasSize(expectedSize);
     }
 }


### PR DESCRIPTION
## Related Issue
#124 

## Description
- 미팅 신청 및 수락을 중복으로 할 수 없도록 변경 (쪽지와 함께 미팅 신청 포함)
- 다음의 API 를 중복해서 여러번 호출할 수 없도록 수정
  - 미팅 신청 
    - (같은 팀에 대한 미팅 요청 상태가 '대기중'인 데이터가 존재하면 예외 발생)
  - 쪽지와 함께 미팅 신청 
    - (같은 팀에 대한 미팅 요청 상태가 '대기중'인 데이터가 존재하면 예외 발생)
  - 미팅 요청 수락
    - (미팅 만료시간이 지나지 않은 성사된 미팅이 데이터가 동일한 팀과 존재한다면 예외 발생)