### PR TITLE
E2 i 131 rim/added function to save service aggrement data to api that create member

### DIFF
--- a/src/main/java/com/e2i/wemeet/domain/member/Member.java
+++ b/src/main/java/com/e2i/wemeet/domain/member/Member.java
@@ -77,6 +77,9 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer credit;
 
+    @Column(nullable = false)
+    private Boolean allowMarketing;
+
     @Embedded
     private ProfileImage profileImage;
 
@@ -93,7 +96,7 @@ public class Member extends BaseTimeEntity {
     @Builder
     public Member(String nickname, Gender gender, String phoneNumber, String email,
         CollegeInfo collegeInfo, Mbti mbti, Integer credit, Boolean imageAuth,
-        ProfileImage profileImage, Role role) {
+        Boolean allowMarketing, ProfileImage profileImage, Role role) {
         this.nickname = nickname;
         this.gender = gender;
         this.phoneNumber = phoneNumber;
@@ -101,6 +104,7 @@ public class Member extends BaseTimeEntity {
         this.collegeInfo = collegeInfo;
         this.mbti = mbti;
         this.credit = credit;
+        this.allowMarketing = allowMarketing;
         this.profileImage = profileImage;
         this.role = role;
     }

--- a/src/main/java/com/e2i/wemeet/dto/request/member/CreateMemberRequestDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/request/member/CreateMemberRequestDto.java
@@ -5,6 +5,7 @@ import com.e2i.wemeet.domain.member.Member;
 import com.e2i.wemeet.domain.member.data.Gender;
 import com.e2i.wemeet.domain.member.data.Mbti;
 import com.e2i.wemeet.domain.member.data.Role;
+import com.e2i.wemeet.util.validator.bean.BooleanTypeValid;
 import com.e2i.wemeet.util.validator.bean.GenderValid;
 import com.e2i.wemeet.util.validator.bean.MbtiValid;
 import com.e2i.wemeet.util.validator.bean.NicknameValid;
@@ -33,7 +34,11 @@ public record CreateMemberRequestDto(
 
     @NotNull
     @MbtiValid
-    String mbti
+    String mbti,
+
+    @NotNull
+    @BooleanTypeValid
+    Boolean allowMarketing
 
 ) {
 
@@ -44,6 +49,7 @@ public record CreateMemberRequestDto(
             .phoneNumber(this.phoneNumber)
             .collegeInfo(this.collegeInfo.toCollegeInfo(collegeCode))
             .mbti(Mbti.valueOf(this.mbti))
+            .allowMarketing(this.allowMarketing)
             .credit(40)
             .imageAuth(false)
             .role(Role.USER)

--- a/src/main/java/com/e2i/wemeet/security/provider/SmsUserDetailsService.java
+++ b/src/main/java/com/e2i/wemeet/security/provider/SmsUserDetailsService.java
@@ -21,6 +21,11 @@ public class SmsUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(final String username) throws UsernameNotFoundException {
         Optional<Member> member = memberRepository.findByPhoneNumber(username);
 
+        if (member.isPresent() && member.get().getDeletedAt() != null) {
+            memberRepository.delete(member.get());
+            member = Optional.empty();
+        }
+
         // SMS 인증을 요청한 사용자가 회원가입이 되어있지 않을 경우
         return member.map(MemberPrincipal::new)
             .orElseGet(MemberPrincipal::new);

--- a/src/main/java/com/e2i/wemeet/util/validator/bean/BooleanTypeValid.java
+++ b/src/main/java/com/e2i/wemeet/util/validator/bean/BooleanTypeValid.java
@@ -1,0 +1,22 @@
+package com.e2i.wemeet.util.validator.bean;
+
+import com.e2i.wemeet.util.validator.module.BooleanTypeValidator;
+import jakarta.validation.Constraint;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = BooleanTypeValidator.class)
+public @interface BooleanTypeValid {
+
+
+    String message() default "{boolean.type.valid}";
+
+    Class[] groups() default {};
+
+    Class[] payload() default {};
+
+}

--- a/src/main/java/com/e2i/wemeet/util/validator/module/BooleanTypeValidator.java
+++ b/src/main/java/com/e2i/wemeet/util/validator/module/BooleanTypeValidator.java
@@ -1,0 +1,18 @@
+package com.e2i.wemeet.util.validator.module;
+
+import com.e2i.wemeet.util.validator.bean.BooleanTypeValid;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class BooleanTypeValidator implements ConstraintValidator<BooleanTypeValid, Boolean> {
+
+    @Override
+    public boolean isValid(Boolean value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        String valueString = value.toString();
+        return valueString.equals("true") || valueString.equals("false");
+    }
+}

--- a/src/main/resources/db/migration/V2306210150__create_member.sql
+++ b/src/main/resources/db/migration/V2306210150__create_member.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS `member`
     `image_auth`            tinyint DEFAULT 0,
     `basic_url`             varchar(150),
     `low_url`               varchar(150),
+    `allow_marketing`       tinyint NOT NULL DEFAULT 1,
     `created_at`            datetime(6),
     `modified_at`           datetime(6),
     `deleted_at`            datetime(6),

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -109,6 +109,7 @@ heart.already.exists=이미 오늘의 좋아요를 모두 소진하였습니다.
 not.send.to.own.team=본인 팀에게는 좋아요를 보낼 수 없습니다.
 team.not.exists=팀이 존재하지 않습니다.
 not.equal.role.to.token=토큰에 담긴 권한과 실제 권한이 다릅니다.
+boolean.type.valid=boolean 타입이 아닙니다.
 # Duplicate
 duplicate.meeting.request=해당 팀에게 보낸 미팅 요청이 이미 존재합니다.
 meeting.already.exist=성사된 미팅이 이미 존재합니다.

--- a/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
@@ -247,7 +247,9 @@ class MemberControllerTest extends AbstractControllerUnitTest {
                             .description("학과 (ENGINEERING)"),
                         fieldWithPath("collegeInfo.admissionYear").type(JsonFieldType.STRING)
                             .description("학번 (17)"),
-                        fieldWithPath("mbti").type(JsonFieldType.STRING).description("본인 MBTI")
+                        fieldWithPath("mbti").type(JsonFieldType.STRING).description("본인 MBTI"),
+                        fieldWithPath("allowMarketing").type(JsonFieldType.BOOLEAN)
+                            .description("마케팅 수신 동의 여부")
                     ),
                     responseFields(
                         fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),

--- a/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
+++ b/src/test/java/com/e2i/wemeet/support/fixture/MemberFixture.java
@@ -21,20 +21,20 @@ import java.lang.reflect.Field;
 public enum MemberFixture {
     KAI("카이", Gender.MAN, "+821011112222", "2017e7024@gs.anyang.ac.kr",
         ANYANG.create(), Mbti.INFJ, 100, false,
-        "/v1/asdf", "/v1/kai", Role.USER),
+        "/v1/asdf", "/v1/kai", true, Role.USER),
     RIM("째림", Gender.WOMAN, "+821098764444", "2019a24@woman.ac.kr",
         WOMAN.create(), Mbti.ISFJ, 100, false,
-        "/v1/asdf", "/v1/rim", Role.USER),
+        "/v1/asdf", "/v1/rim", true, Role.USER),
     SEYUN("떼윤", Gender.MAN, "+821090908888", "2020a234@korea.ac.kr",
         KOREA.create(), Mbti.ENFJ, 100, false,
-        "/v1/asdf", "/v1/sey", Role.USER),
+        "/v1/asdf", "/v1/sey", true, Role.USER),
     JEONGYEOL("정열", Gender.MAN, "+8210333344444", "2014p13@korea.ac.kr",
         KOREA.create(), Mbti.ESFJ, 100, false,
-        "/v1/asdf", "/v1/jeong", Role.USER),
+        "/v1/asdf", "/v1/jeong", true, Role.USER),
 
     CHAEWON("채원", Gender.WOMAN, "+821089071365", "2020p13@woman.ac.kr",
         WOMAN.create(), Mbti.ISTJ, 100, false,
-        "/v1/asdf", "/v1/chaechae", Role.USER);
+        "/v1/asdf", "/v1/chaechae", true, Role.USER);
 
     private final String nickname;
     private final Gender gender;
@@ -46,11 +46,12 @@ public enum MemberFixture {
     private final Boolean imageAuth;
     private final String basicUrl;
     private final String lowUrl;
+    private final Boolean allowMarketing;
     private final Role role;
 
     MemberFixture(String nickname, Gender gender, String phoneNumber, String email,
         CollegeInfo collegeInfo, Mbti mbti, Integer credit,
-        Boolean imageAuth, String basicUrl, String lowUrl, Role role) {
+        Boolean imageAuth, String basicUrl, String lowUrl, Boolean allowMarketing, Role role) {
         this.nickname = nickname;
         this.gender = gender;
         this.phoneNumber = phoneNumber;
@@ -61,6 +62,7 @@ public enum MemberFixture {
         this.imageAuth = imageAuth;
         this.basicUrl = basicUrl;
         this.lowUrl = lowUrl;
+        this.allowMarketing = allowMarketing;
         this.role = role;
     }
 
@@ -153,6 +155,7 @@ public enum MemberFixture {
             .mbti(this.mbti)
             .credit(this.credit)
             .profileImage(new ProfileImage(this.basicUrl, this.lowUrl, this.imageAuth))
+            .allowMarketing(this.allowMarketing)
             .role(this.role);
     }
 
@@ -165,6 +168,7 @@ public enum MemberFixture {
             .gender(this.gender.name())
             .mbti(this.mbti.name())
             .collegeInfo(collegeInfoRequestDto)
+            .allowMarketing(this.allowMarketing)
             .build();
     }
 
@@ -177,6 +181,7 @@ public enum MemberFixture {
             .gender(this.gender.name())
             .mbti(this.mbti.name())
             .collegeInfo(collegeInfoRequestDto)
+            .allowMarketing(this.allowMarketing)
             .build();
     }
 


### PR DESCRIPTION
## Related Issue
#131 

## Description
1. 휴대폰 번호 인증 완료시 member 이전 데이터가 있다면 삭제하는 로직을 추가하였습니다.
2. 회원가입시 요청 데이터에 마케팅 수신 동의 데이터를 추가하였습니다.
