### PR TITLE
refactor(member): add university authentication status data to response values in member details API

### DIFF
--- a/src/main/java/com/e2i/wemeet/dto/response/member/MemberDetailResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/member/MemberDetailResponseDto.java
@@ -13,7 +13,8 @@ public record MemberDetailResponseDto(
     String college,
     String collegeType,
     String admissionYear,
-    ProfileImageResponseDto profileImage
+    ProfileImageResponseDto profileImage,
+    Boolean authUnivStatus
 ) {
 
     public static MemberDetailResponseDto of(final Member member, final String college) {
@@ -27,6 +28,7 @@ public record MemberDetailResponseDto(
             .collegeType(member.getCollegeInfo().getCollegeType().getDescription())
             .admissionYear(member.getCollegeInfo().getAdmissionYear())
             .profileImage(profileImage)
+            .authUnivStatus(member.getEmail() != null)
             .build();
     }
 }

--- a/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/member/MemberControllerTest.java
@@ -288,7 +288,9 @@ class MemberControllerTest extends AbstractControllerUnitTest {
                         fieldWithPath("data.profileImage.basicUrl").type(JsonFieldType.STRING)
                             .description("회원 개인 프로필 사진 원본"),
                         fieldWithPath("data.profileImage.lowUrl").type(JsonFieldType.STRING)
-                            .description("회원 개인 프로필 사진 저해상도")
+                            .description("회원 개인 프로필 사진 저해상도"),
+                        fieldWithPath("data.authUnivStatus").type(JsonFieldType.BOOLEAN)
+                            .description("대학 인증 여부")
                     )
                 ));
     }

--- a/src/test/java/com/e2i/wemeet/service/member/MemberServiceTest.java
+++ b/src/test/java/com/e2i/wemeet/service/member/MemberServiceTest.java
@@ -214,8 +214,9 @@ class MemberServiceTest {
             MemberDetailResponseDto memberDetailResponseDto = memberService.readMemberDetail(
                 kai.getMemberId());
             assertThat(memberDetailResponseDto).isNotNull()
-                .extracting("nickname", "college", "collegeType", "mbti", "admissionYear")
-                .contains(kai.getNickname(), "안양대", "인문사회", Mbti.INFJ, "17");
+                .extracting("nickname", "college", "collegeType", "mbti", "admissionYear",
+                    "authUnivStatus")
+                .contains(kai.getNickname(), "안양대", "인문사회", Mbti.INFJ, "17", true);
         }
 
         @DisplayName("회원 ID가 잘못되었을 경우, 회원 정보를 조회할 수 없다.")


### PR DESCRIPTION
## Related Issue
#143 
## Description
마이페이지 조회 API에 사용자의 대학 인증 여부 데이터를 추가하였습니다.
