### PR TITLE
refactor: add admissionYear for teamLeader to api response

### DIFF
--- a/src/main/java/com/e2i/wemeet/domain/heart/HeartCustomRepositoryImpl.java
+++ b/src/main/java/com/e2i/wemeet/domain/heart/HeartCustomRepositoryImpl.java
@@ -34,10 +34,13 @@ public class HeartCustomRepositoryImpl implements HeartCustomRepository {
                     Projections.constructor(TeamLeaderData.class, member.nickname,
                         member.mbti,
                         member.profileImage.basicUrl.as("profileImageUrl"),
-                        member.collegeInfo.collegeCode.codeValue.as("college"))))
+                        member.collegeInfo.collegeCode.codeValue.as("college"),
+                        member.collegeInfo.admissionYear.as("admissionYear")
+                    )))
             .from(heart)
             .join(team).on(heart.team.teamId.eq(team.teamId))
-            .join(heart.partnerTeam.teamLeader, member).on(heart.partnerTeam.teamLeader.memberId.eq(member.memberId))
+            .join(heart.partnerTeam.teamLeader, member)
+            .on(heart.partnerTeam.teamLeader.memberId.eq(member.memberId))
             .join(teamImage).on(teamImage.team.teamId.eq(heart.partnerTeam.teamId))
             .where(
                 team.teamId.eq(teamId),
@@ -61,10 +64,12 @@ public class HeartCustomRepositoryImpl implements HeartCustomRepository {
                     heart.createdAt,
                     Projections.constructor(TeamLeaderData.class, member.nickname, member.mbti,
                         member.profileImage.basicUrl.as("profileImageUrl"),
-                        member.collegeInfo.collegeCode.codeValue.as("college"))))
+                        member.collegeInfo.collegeCode.codeValue.as("college"),
+                        member.collegeInfo.admissionYear.as("admissionYear"))))
             .from(heart)
             .join(team).on(heart.partnerTeam.teamId.eq(team.teamId))
-            .join(heart.team.teamLeader, member).on(heart.team.teamLeader.memberId.eq(member.memberId))
+            .join(heart.team.teamLeader, member)
+            .on(heart.team.teamLeader.memberId.eq(member.memberId))
             .join(teamImage).on(teamImage.team.teamId.eq(heart.team.teamId))
             .where(
                 team.teamId.eq(teamId),

--- a/src/main/java/com/e2i/wemeet/domain/team/data/suggestion/TeamLeaderData.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/data/suggestion/TeamLeaderData.java
@@ -8,7 +8,8 @@ public record TeamLeaderData(
     String nickname,
     Mbti mbti,
     String profileImageUrl,
-    String college
+    String college,
+    String admissionYear
 ) {
 
 }

--- a/src/main/java/com/e2i/wemeet/domain/team/suggestion/SuggestionRepositoryImpl.java
+++ b/src/main/java/com/e2i/wemeet/domain/team/suggestion/SuggestionRepositoryImpl.java
@@ -26,7 +26,7 @@ public class SuggestionRepositoryImpl implements SuggestionRepository {
     private final JPAQueryFactory queryFactory;
     private static final int SUGGESTION_TEAM_LIMIT = 3;
     private static final LocalTime boundaryTime = LocalTime.of(23, 11);
-    
+
 
     @Override
     public List<SuggestionTeamData> findSuggestionTeamForUser(Long memberId, Gender gender) {
@@ -44,7 +44,8 @@ public class SuggestionRepositoryImpl implements SuggestionRepository {
                     teamImage.teamImageUrl.as("teamMainImageUrl"),
                     Projections.constructor(TeamLeaderData.class, member.nickname, member.mbti,
                         member.profileImage.lowUrl.as("profileImageUrl"),
-                        member.collegeInfo.collegeCode.codeValue.as("college"))
+                        member.collegeInfo.collegeCode.codeValue.as("college"),
+                        member.collegeInfo.admissionYear.as("admissionYear"))
                 )
             )
             .from(team)
@@ -88,7 +89,8 @@ public class SuggestionRepositoryImpl implements SuggestionRepository {
                     team.region, teamImage.teamImageUrl.as("teamMainImageUrl"), history.isLiked,
                     Projections.constructor(TeamLeaderData.class, member.nickname, member.mbti,
                         member.profileImage.lowUrl.as("profileImageUrl"),
-                        member.collegeInfo.collegeCode.codeValue.as("college"))
+                        member.collegeInfo.collegeCode.codeValue.as("college"),
+                        member.collegeInfo.admissionYear.as("admissionYear"))
                 )
             )
             .from(history)

--- a/src/main/java/com/e2i/wemeet/dto/response/suggestion/SuggestionResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/suggestion/SuggestionResponseDto.java
@@ -25,6 +25,7 @@ public record SuggestionResponseDto(
                 .college(data.teamLeader().college())
                 .nickname(data.teamLeader().nickname())
                 .mbti(data.teamLeader().mbti().name())
+                .admissionYear(data.teamLeader().admissionYear())
                 .build()
             ).build();
     }

--- a/src/main/java/com/e2i/wemeet/dto/response/suggestion/TeamLeaderResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/suggestion/TeamLeaderResponseDto.java
@@ -7,7 +7,8 @@ import lombok.Builder;
 public record TeamLeaderResponseDto(
     String nickname,
     String mbti,
-    String college
+    String college,
+    String admissionYear
 ) {
 
     public static TeamLeaderResponseDto of(TeamLeaderData data) {
@@ -15,6 +16,7 @@ public record TeamLeaderResponseDto(
             .nickname(data.nickname())
             .mbti(data.mbti().name())
             .college(data.college())
+            .admissionYear(data.admissionYear())
             .build();
     }
 }

--- a/src/main/java/com/e2i/wemeet/dto/response/team/MyTeamDetailResponseDto.java
+++ b/src/main/java/com/e2i/wemeet/dto/response/team/MyTeamDetailResponseDto.java
@@ -41,7 +41,8 @@ public record MyTeamDetailResponseDto(
             .leader(TeamLeaderResponseDto.builder()
                 .nickname(teamLeader.getNickname())
                 .mbti(teamLeader.getMbti().name())
-                .college(teamLeader.getCollegeInfo().getCollegeCode().getCodeValue()).build()
+                .college(teamLeader.getCollegeInfo().getCollegeCode().getCodeValue())
+                .admissionYear(teamLeader.getCollegeInfo().getAdmissionYear()).build()
             )
             .images(
                 teamImages.stream()

--- a/src/test/java/com/e2i/wemeet/controller/heart/HeartControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/heart/HeartControllerTest.java
@@ -108,6 +108,7 @@ class HeartControllerTest extends AbstractControllerUnitTest {
                     .nickname("팀장님")
                     .college("서울대")
                     .mbti("ENFP")
+                    .admissionYear("19")
                     .build())
                 .build();
 
@@ -129,7 +130,8 @@ class HeartControllerTest extends AbstractControllerUnitTest {
                     jsonPath("$.data[0].profileImageURL").value("https://test.image.com"),
                     jsonPath("$.data[0].leader.nickname").value("팀장님"),
                     jsonPath("$.data[0].leader.college").value("서울대"),
-                    jsonPath("$.data[0].leader.mbti").value("ENFP")
+                    jsonPath("$.data[0].leader.mbti").value("ENFP"),
+                    jsonPath("$.data[0].leader.admissionYear").value("19")
                 );
             verify(heartService).getSentHeart(anyLong(), any());
 
@@ -169,7 +171,9 @@ class HeartControllerTest extends AbstractControllerUnitTest {
                             fieldWithPath("data[].leader.college").type(JsonFieldType.STRING)
                                 .description("상대 팀 팀장 대학교"),
                             fieldWithPath("data[].leader.mbti").type(JsonFieldType.STRING)
-                                .description("상대 팀 팀장 MBTI")
+                                .description("상대 팀 팀장 MBTI"),
+                            fieldWithPath("data[].leader.admissionYear").type(JsonFieldType.STRING)
+                                .description("상대 팀 팀장 학번")
                         )));
         }
 
@@ -192,6 +196,7 @@ class HeartControllerTest extends AbstractControllerUnitTest {
                     .nickname("팀장님")
                     .college("서울대")
                     .mbti("ENFP")
+                    .admissionYear("19")
                     .build())
                 .build();
 
@@ -213,7 +218,8 @@ class HeartControllerTest extends AbstractControllerUnitTest {
                     jsonPath("$.data[0].profileImageURL").value("https://test.image.com"),
                     jsonPath("$.data[0].leader.nickname").value("팀장님"),
                     jsonPath("$.data[0].leader.college").value("서울대"),
-                    jsonPath("$.data[0].leader.mbti").value("ENFP")
+                    jsonPath("$.data[0].leader.mbti").value("ENFP"),
+                    jsonPath("$.data[0].leader.admissionYear").value("19")
                 );
             verify(heartService).getReceivedHeart(anyLong(), any());
 
@@ -253,7 +259,9 @@ class HeartControllerTest extends AbstractControllerUnitTest {
                             fieldWithPath("data[].leader.college").type(JsonFieldType.STRING)
                                 .description("상대 팀 팀장 대학교"),
                             fieldWithPath("data[].leader.mbti").type(JsonFieldType.STRING)
-                                .description("상대 팀 팀장 MBTI")
+                                .description("상대 팀 팀장 MBTI"),
+                            fieldWithPath("data[].leader.admissionYear").type(JsonFieldType.STRING)
+                                .description("상대 팀 팀장 학번")
                         )));
         }
     }

--- a/src/test/java/com/e2i/wemeet/controller/suggestion/SuggestionControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/suggestion/SuggestionControllerTest.java
@@ -42,6 +42,7 @@ class SuggestionControllerTest extends AbstractControllerUnitTest {
                     .college("서울대학교")
                     .mbti(Mbti.ENFP.name())
                     .nickname("짱구")
+                    .admissionYear("19")
                     .build())
             .build();
 
@@ -58,7 +59,8 @@ class SuggestionControllerTest extends AbstractControllerUnitTest {
                 jsonPath("$.data[0].profileImageURL").value(response.profileImageURL()),
                 jsonPath("$.data[0].leader.college").value(response.leader().college()),
                 jsonPath("$.data[0].leader.mbti").value(Mbti.ENFP.name()),
-                jsonPath("$.data[0].leader.nickname").value(response.leader().nickname())
+                jsonPath("$.data[0].leader.nickname").value(response.leader().nickname()),
+                jsonPath("$.data[0].leader.admissionYear").value(response.leader().admissionYear())
             );
         verify(suggestionService).readSuggestion(anyLong(), any());
 
@@ -84,6 +86,7 @@ class SuggestionControllerTest extends AbstractControllerUnitTest {
                                 .college("서울대학교")
                                 .mbti(Mbti.ENFP.name())
                                 .nickname("짱구")
+                                .admissionYear("19")
                                 .build())
                         .build()
                 )
@@ -139,7 +142,10 @@ class SuggestionControllerTest extends AbstractControllerUnitTest {
                             .description("추천 팀 팀장 MBTI"),
                         fieldWithPath("data[].leader.college").type(
                                 JsonFieldType.STRING)
-                            .description("추천 팀 팀장 대학교")
+                            .description("추천 팀 팀장 대학교"),
+                        fieldWithPath("data[].leader.admissionYear").type(
+                                JsonFieldType.STRING)
+                            .description("추천 팀 팀장 학번")
                     )
                 ));
 
@@ -179,7 +185,10 @@ class SuggestionControllerTest extends AbstractControllerUnitTest {
                         fieldWithPath("data.teams[].leader.mbti").type(JsonFieldType.STRING)
                             .description("추천 팀 팀장 MBTI"),
                         fieldWithPath("data.teams[].leader.college").type(JsonFieldType.STRING)
-                            .description("추천 팀 팀장 대학교")
+                            .description("추천 팀 팀장 대학교"),
+                        fieldWithPath("data.teams[].leader.admissionYear").type(
+                                JsonFieldType.STRING)
+                            .description("추천 팀 팀장 학번")
                     )
                 ));
     }

--- a/src/test/java/com/e2i/wemeet/controller/team/TeamControllerTest.java
+++ b/src/test/java/com/e2i/wemeet/controller/team/TeamControllerTest.java
@@ -195,7 +195,8 @@ class TeamControllerTest extends AbstractControllerUnitTest {
         LeaderResponseDto leader = LeaderResponseDto.of(kai);
         List<String> imageUrls = List.of("/v1/test1", "/v1/test2", "/v1/test3");
 
-        final TeamDetailResponseDto response = TeamDetailResponseDto.of(teamInformation, leader, imageUrls);
+        final TeamDetailResponseDto response = TeamDetailResponseDto.of(teamInformation, leader,
+            imageUrls);
         given(teamService.readByTeamId(anyLong(), anyLong(), any(LocalDateTime.class)))
             .willReturn(response);
 
@@ -289,7 +290,8 @@ class TeamControllerTest extends AbstractControllerUnitTest {
                                 .description("음주 수치"),
                             fieldWithPath("drinkWithGame").type(JsonFieldType.STRING)
                                 .description("술게임 여부"),
-                            fieldWithPath("additionalActivity").type(JsonFieldType.STRING).optional()
+                            fieldWithPath("additionalActivity").type(JsonFieldType.STRING)
+                                .optional()
                                 .description("추가 활동"),
                             fieldWithPath("introduction").type(JsonFieldType.STRING)
                                 .description("팀 소개"),
@@ -365,12 +367,14 @@ class TeamControllerTest extends AbstractControllerUnitTest {
                                 """)
                         .requestFields(
                             fieldWithPath("images").description("사진 파일"),
-                            fieldWithPath("data.region").type(JsonFieldType.STRING).description("선호 지역"),
+                            fieldWithPath("data.region").type(JsonFieldType.STRING)
+                                .description("선호 지역"),
                             fieldWithPath("data.drinkRate").type(JsonFieldType.STRING)
                                 .description("음주 수치"),
                             fieldWithPath("data.drinkWithGame").type(JsonFieldType.STRING)
                                 .description("술게임 여부"),
-                            fieldWithPath("data.additionalActivity").type(JsonFieldType.STRING).optional()
+                            fieldWithPath("data.additionalActivity").type(JsonFieldType.STRING)
+                                .optional()
                                 .description("추가 활동"),
                             fieldWithPath("data.introduction").type(JsonFieldType.STRING)
                                 .description("팀 소개"),
@@ -454,7 +458,9 @@ class TeamControllerTest extends AbstractControllerUnitTest {
                         fieldWithPath("data.team.leader.mbti").type(JsonFieldType.STRING)
                             .description("팀장 MBTI"),
                         fieldWithPath("data.team.leader.college").type(JsonFieldType.STRING)
-                            .description("팀장 대학교 정보")
+                            .description("팀장 대학교 정보"),
+                        fieldWithPath("data.team.leader.admissionYear").type(JsonFieldType.STRING)
+                            .description("팀장 학번")
                     )
                 ));
     }


### PR DESCRIPTION
## Related Issue
#147
## Description
카드가 사용되는 모든 API의 응답 값에 팀장의 학번 정보를 추가하였습니다.

## Checklist:
- [x] 받은/보낸 좋아요 조회
- [x] 받은/보낸 미팅 신청 조회
- [x] 내 팀 조회
- [x] 상대 팀 조회
- [x] 추천 팀 목록 조회